### PR TITLE
Position resize fix

### DIFF
--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.tsx
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.tsx
@@ -204,12 +204,19 @@ export const createDraggableBlocksPlugin = () => {
         //   // event.dataTransfer!.;
         //   return false;
         // },
-        mouseleave(_view, _event) {
+        mouseleave(view, event) {
           if (!dropElement) {
             throw new Error("unexpected");
           }
-          // TODO
-          // dropElement.style.display = "none";
+
+          // Hide the drop element when the mouse leaves the editor from the bottom
+          // This is not in mouse move because the mouse leaving the bottom of the editor
+          // Is not detected there
+          if (event.clientY > view.dom.clientTop + view.dom.clientHeight) {
+            menuShown = false;
+            addClicked = false;
+            ReactDOM.render(<></>, dropElement);
+          }
           return true;
         },
         mousedown(_view, _event) {
@@ -265,15 +272,25 @@ export const createDraggableBlocksPlugin = () => {
           dropElement.style.left = left + "px";
           dropElement.style.top = rect.top + "px";
 
+          // Check whether mouse is in block or not so we can hide draghandle
+          const mouseInBlock =
+            rect.left - WIDTH + win.pageXOffset < event.clientX && // Left bound
+            rect.left + rect.width + win.pageXOffset > event.clientX && // Right bound
+            rect.top - win.pageYOffset < event.clientY; // Top bound
+
           ReactDOM.render(
-            <DragHandle
-              onShow={onShow}
-              onHide={onHide}
-              onAddClicked={onAddClicked}
-              key={block.id + ""}
-              view={view}
-              coords={coords}
-            />,
+            mouseInBlock ? (
+              <DragHandle
+                onShow={onShow}
+                onHide={onHide}
+                onAddClicked={onAddClicked}
+                key={block.id + ""}
+                view={view}
+                coords={coords}
+              />
+            ) : (
+              <></>
+            ),
             dropElement
           );
           return true;


### PR DESCRIPTION
#15 
The issue was that the horizontal anchor was set only when the page opened. I added an event handler on the 'resize' event to update the horizontal anchor. This brought a new issue that the anchor is updated but there is no transaction and as a result the drag handle on re-renders after the mouse is moved. I fixed this by moving the render functionality into a function and created a transaction each time the page resize, and calling the render function.
![thanksnoam](https://user-images.githubusercontent.com/36531255/159526216-8c43ab2d-636d-4abf-876d-ab7f796b75e8.gif)
