### PR TITLE
fix copy-paste

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -103,6 +103,7 @@ export const Block = Node.create<IBlock>({
     return [
       {
         tag: "div",
+        context: "blockgroup/",
       },
     ];
   },

--- a/packages/core/src/extensions/Blocks/nodes/Content.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Content.ts
@@ -32,6 +32,7 @@ export const ContentBlock = Node.create<IBlock>({
     return [
       {
         tag: "div",
+        context: "block/",
       },
     ];
   },


### PR DESCRIPTION
The copy-paste functionality within the app was broken because there was no way for the parsing rule to distinguish between `block`/`blockgroup`/`content`.

In this PR, added extra rule conditions for `block` and `content` to disambiguate.

_NOTE: Copy-pasting external document "into" the editor is still problematic after this fix._