### PR TITLE
Re-add data-id attribute to blocks

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -163,14 +163,16 @@ export const Block = Node.create<IBlock>({
 
     return [
       "div",
-      mergeAttributes(HTMLAttributes, attrs, {
+      mergeAttributes(attrs, {
         class: styles.blockOuter,
+        "data-id": HTMLAttributes['data-id'],
         "data-node-type": "block-outer",
       }),
       [
         "div",
-        mergeAttributes(HTMLAttributes, attrs, {
+        mergeAttributes(attrs, {
           class: styles.block,
+          "data-id": HTMLAttributes["data-id"],
           "data-node-type": "block",
         }),
         0,

--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -163,13 +163,13 @@ export const Block = Node.create<IBlock>({
 
     return [
       "div",
-      mergeAttributes(attrs, {
+      mergeAttributes(HTMLAttributes, attrs, {
         class: styles.blockOuter,
         "data-node-type": "block-outer",
       }),
       [
         "div",
-        mergeAttributes(attrs, {
+        mergeAttributes(HTMLAttributes, attrs, {
           class: styles.block,
           "data-node-type": "block",
         }),


### PR DESCRIPTION
This PR fixes a bug introduced in the previous commit which removed the `data-id` attribute from blocks, which most notably causes issues with the drag handle.