### PR TITLE
Block animation fix

### DIFF
--- a/packages/core/src/extensions/Blocks/BlockAttributes.ts
+++ b/packages/core/src/extensions/Blocks/BlockAttributes.ts
@@ -1,26 +1,5 @@
-type attrParsingFunction = (
-  [nodeAttr, HTMLAttr]: [string, string],
-  ...others: any
-) => [string, string] | null;
-
-/**
- * Creates a new attributes object by parsing all possible block attributes with a user-defined function.
- * @param fn Function which takes an array of 2 strings as an argument and also returns an array of 2 strings or null.
- * The argument array contains a given TipTap node attribute and corresponding HTML attribute. The function should
- * return null for any argument attributes that should not be added to the returned object.
- */
-export function parseAttrs(fn: attrParsingFunction): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(BlockAttributes)
-      // Filters out all attributes where the parsing function returns null.
-      .filter(([nodeAttr, HTMLAttr]) => fn([nodeAttr, HTMLAttr]) !== null)
-      // Parses attributes - the parsing function will no longer return null on any attribute.
-      .map(([nodeAttr, HTMLAttr]) => fn([nodeAttr, HTMLAttr])!)
-  );
-}
-
 // Object containing all possible block attributes.
-export const BlockAttributes: Record<string, string> = {
+const BlockAttributes: Record<string, string> = {
   listType: "data-list-type",
   blockColor: "data-block-color",
   blockStyle: "data-block-style",
@@ -29,3 +8,5 @@ export const BlockAttributes: Record<string, string> = {
   depth: "data-depth",
   depthChange: "data-depth-change",
 };
+
+export default BlockAttributes;

--- a/packages/core/src/extensions/Blocks/BlockAttributes.ts
+++ b/packages/core/src/extensions/Blocks/BlockAttributes.ts
@@ -1,0 +1,31 @@
+type attrParsingFunction = (
+  [nodeAttr, HTMLAttr]: [string, string],
+  ...others: any
+) => [string, string] | null;
+
+/**
+ * Creates a new attributes object by parsing all possible block attributes with a user-defined function.
+ * @param fn Function which takes an array of 2 strings as an argument and also returns an array of 2 strings or null.
+ * The argument array contains a given TipTap node attribute and corresponding HTML attribute. The function should
+ * return null for any argument attributes that should not be added to the returned object.
+ */
+export function parseAttrs(fn: attrParsingFunction): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(BlockAttributes)
+      // Filters out all attributes where the parsing function returns null.
+      .filter(([nodeAttr, HTMLAttr]) => fn([nodeAttr, HTMLAttr]) !== null)
+      // Parses attributes - the parsing function will no longer return null on any attribute.
+      .map(([nodeAttr, HTMLAttr]) => fn([nodeAttr, HTMLAttr])!)
+  );
+}
+
+// Object containing all possible block attributes.
+export const BlockAttributes: Record<string, string> = {
+  listType: "data-list-type",
+  blockColor: "data-block-color",
+  blockStyle: "data-block-style",
+  headingType: "data-heading-type",
+  id: "data-id",
+  depth: "data-depth",
+  depthChange: "data-depth-change",
+};

--- a/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
+++ b/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
@@ -5,7 +5,7 @@ import {
 } from "@tiptap/core";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
-import { BlockAttributes } from "./BlockAttributes";
+import BlockAttributes from "./BlockAttributes";
 
 const PLUGIN_KEY = new PluginKey(`previous-blocks`);
 
@@ -134,8 +134,8 @@ export const PreviousBlockTypePlugin = () => {
           }
 
           const decorationAttributes: any = {};
-          for (let [key, val] of Object.entries(prevAttrs)) {
-            decorationAttributes[insertPrev(BlockAttributes[key])] =
+          for (let [nodeAttr, val] of Object.entries(prevAttrs)) {
+            decorationAttributes[insertPrev(BlockAttributes[nodeAttr])] =
               val || "none";
           }
           const decoration = Decoration.node(pos, pos + node.nodeSize, {

--- a/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
+++ b/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
@@ -8,6 +8,13 @@ import { Decoration, DecorationSet } from "prosemirror-view";
 
 const PLUGIN_KEY = new PluginKey(`previous-blocks`);
 
+// Used to change HTML attribute string from camelCase to kebab-case to better follow naming conventions.
+const changeAttributeCase = (str: string) =>
+  str.replace(
+    /[A-Z]+(?![a-z])|[A-Z]/g,
+    ($, ofs) => (ofs ? "-" : "") + $.toLowerCase()
+  );
+
 /**
  * This plugin tracks transformation of Block node attributes, so we can support CSS transitions.
  *
@@ -130,7 +137,8 @@ export const PreviousBlockTypePlugin = () => {
 
           const decorationAttributes: any = {};
           for (let [key, val] of Object.entries(prevAttrs)) {
-            decorationAttributes["data-prev-" + key] = val || "none";
+            decorationAttributes["data-prev-" + changeAttributeCase(key)] =
+              val || "none";
           }
           const decoration = Decoration.node(pos, pos + node.nodeSize, {
             ...decorationAttributes,

--- a/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
+++ b/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
@@ -5,15 +5,13 @@ import {
 } from "@tiptap/core";
 import { Plugin, PluginKey } from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
+import { BlockAttributes } from "./BlockAttributes";
 
 const PLUGIN_KEY = new PluginKey(`previous-blocks`);
 
-// Used to change HTML attribute string from camelCase to kebab-case to better follow naming conventions.
-const changeAttributeCase = (str: string) =>
-  str.replace(
-    /[A-Z]+(?![a-z])|[A-Z]/g,
-    ($, ofs) => (ofs ? "-" : "") + $.toLowerCase()
-  );
+// Inserts "prev-" string into an HTML attribute name with a "data-" prefix, e.g. "data-depth" -> "data-prev-depth".
+// Assumes "data-" prefix is in the attribute name.
+const insertPrev = (attr: string) => attr.slice(0, 5) + "prev-" + attr.slice(5);
 
 /**
  * This plugin tracks transformation of Block node attributes, so we can support CSS transitions.
@@ -137,7 +135,7 @@ export const PreviousBlockTypePlugin = () => {
 
           const decorationAttributes: any = {};
           for (let [key, val] of Object.entries(prevAttrs)) {
-            decorationAttributes["data-prev-" + changeAttributeCase(key)] =
+            decorationAttributes[insertPrev(BlockAttributes[key])] =
               val || "none";
           }
           const decoration = Decoration.node(pos, pos + node.nodeSize, {

--- a/packages/core/src/extensions/Blocks/nodes/Block.module.css
+++ b/packages/core/src/extensions/Blocks/nodes/Block.module.css
@@ -40,7 +40,7 @@ NESTED BLOCKS
   position: relative;
 }
 
-.blockGroup .blockGroup > .blockOuter:not([data-prev-depthchanged])::before {
+.blockGroup .blockGroup > .blockOuter:not([data-prev-depth-changed])::before {
   content: " ";
   display: inline;
   border-left: 1px solid #ccc;
@@ -50,49 +50,49 @@ NESTED BLOCKS
   transition: all 0.2s 0.1s;
 }
 
-.blockGroup .blockGroup > .blockOuter[data-prev-depthchange="-2"]::before {
+.blockGroup .blockGroup > .blockOuter[data-prev-depth-change="-2"]::before {
   height: 0;
 }
 
 /* NESTED BLOCK ANIMATIONS */
 
-[data-prev-depthchange="1"] {
+[data-prev-depth-change="1"] {
   --x: 1;
 }
-[data-prev-depthchange="2"] {
+[data-prev-depth-change="2"] {
   --x: 2;
 }
-[data-prev-depthchange="3"] {
+[data-prev-depth-change="3"] {
   --x: 3;
 }
-[data-prev-depthchange="4"] {
+[data-prev-depth-change="4"] {
   --x: 4;
 }
-[data-prev-depthchange="5"] {
+[data-prev-depth-change="5"] {
   --x: 5;
 }
 
-[data-prev-depthchange="-1"] {
+[data-prev-depth-change="-1"] {
   --x: -1;
 }
-[data-prev-depthchange="-2"] {
+[data-prev-depth-change="-2"] {
   --x: -2;
 }
-[data-prev-depthchange="-3"] {
+[data-prev-depth-change="-3"] {
   --x: -3;
 }
-[data-prev-depthchange="-4"] {
+[data-prev-depth-change="-4"] {
   --x: -4;
 }
-[data-prev-depthchange="-5"] {
+[data-prev-depth-change="-5"] {
   --x: -5;
 }
 
-.blockOuter[data-prev-depthchange] {
+.blockOuter[data-prev-depth-change] {
   margin-left: calc(10px * var(--x));
 }
 
-.blockOuter[data-prev-depthchange] .blockOuter[data-prev-depthchange] {
+.blockOuter[data-prev-depth-change] .blockOuter[data-prev-depth-change] {
   margin-left: 0;
 }
 

--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -7,6 +7,7 @@ import { OrderedListPlugin } from "../OrderedListPlugin";
 import { PreviousBlockTypePlugin } from "../PreviousBlockTypePlugin";
 import { textblockTypeInputRuleSameNodeType } from "../rule";
 import styles from "./Block.module.css";
+import { parseAttrs } from "../BlockAttributes";
 
 export interface IBlock {
   HTMLAttributes: Record<string, any>;
@@ -84,21 +85,12 @@ export const Block = Node.create<IBlock>({
             return false;
           }
 
-          // Only adds attributes if they're actually present in the element.
-          const attrs = {
-            ...(element.getAttribute("data-list-type") && {
-              listType: element.getAttribute("data-list-type"),
-            }),
-            ...(element.getAttribute("data-block-color") && {
-              blockColor: element.getAttribute("data-block-color"),
-            }),
-            ...(element.getAttribute("data-block-style") && {
-              blockStyle: element.getAttribute("data-block-style"),
-            }),
-            ...(element.getAttribute("data-heading-type") && {
-              headingType: element.getAttribute("data-heading-type"),
-            }),
-          };
+          const attrs = parseAttrs(([nodeAttr, HTMLAttr]) => {
+            if (element.getAttribute(HTMLAttr)) {
+              return [nodeAttr, element.getAttribute(HTMLAttr)!];
+            }
+            return null;
+          });
 
           if (element.getAttribute("data-node-type") === "block") {
             return attrs;
@@ -154,25 +146,21 @@ export const Block = Node.create<IBlock>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const attrs = {
-      "data-list-type": HTMLAttributes.listType,
-      "data-block-color": HTMLAttributes.blockColor,
-      "data-block-style": HTMLAttributes.blockStyle,
-      "data-heading-type": HTMLAttributes.headingType,
-    };
+    const attrs = parseAttrs(([nodeAttr, HTMLAttr]) => [
+      HTMLAttr,
+      HTMLAttributes[nodeAttr],
+    ]);
 
     return [
       "div",
       mergeAttributes(attrs, {
         class: styles.blockOuter,
-        "data-id": HTMLAttributes['data-id'],
         "data-node-type": "block-outer",
       }),
       [
         "div",
         mergeAttributes(attrs, {
           class: styles.block,
-          "data-id": HTMLAttributes["data-id"],
           "data-node-type": "block",
         }),
         0,

--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -7,7 +7,7 @@ import { OrderedListPlugin } from "../OrderedListPlugin";
 import { PreviousBlockTypePlugin } from "../PreviousBlockTypePlugin";
 import { textblockTypeInputRuleSameNodeType } from "../rule";
 import styles from "./Block.module.css";
-import { parseAttrs } from "../BlockAttributes";
+import BlockAttributes from "../BlockAttributes";
 
 export interface IBlock {
   HTMLAttributes: Record<string, any>;
@@ -85,12 +85,12 @@ export const Block = Node.create<IBlock>({
             return false;
           }
 
-          const attrs = parseAttrs(([nodeAttr, HTMLAttr]) => {
+          const attrs: Record<string, string> = {};
+          for (let [nodeAttr, HTMLAttr] of Object.entries(BlockAttributes)) {
             if (element.getAttribute(HTMLAttr)) {
-              return [nodeAttr, element.getAttribute(HTMLAttr)!];
+              attrs[nodeAttr] = element.getAttribute(HTMLAttr)!;
             }
-            return null;
-          });
+          }
 
           if (element.getAttribute("data-node-type") === "block") {
             return attrs;
@@ -146,10 +146,10 @@ export const Block = Node.create<IBlock>({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const attrs = parseAttrs(([nodeAttr, HTMLAttr]) => [
-      HTMLAttr,
-      HTMLAttributes[nodeAttr],
-    ]);
+    const attrs: Record<string, string> = {};
+    for (let [nodeAttr, HTMLAttr] of Object.entries(BlockAttributes)) {
+      attrs[HTMLAttr] = HTMLAttributes[nodeAttr];
+    }
 
     return [
       "div",


### PR DESCRIPTION
BlockNote keeps track of what node type a block currently is (paragraph, heading, list, etc), as well as what type it was previously. This is done using custom HTML attributes using kebab-case (e.g. `data-heading-type` and `prev-data-heading-type`) to animate when the block type changes. Previously, these attributes used improper naming conventions (actually `data-headingType` and `prev-data-headingType`). PR #46 improved the naming scheme for the current block type attribute but not the previous type, which broke animations. This PR changes the previous block type attribute to also comply with kebab-case naming conventions, and subsequently fixes the animations.