### PR TITLE
Move block `id` attribute rendering code

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -148,7 +148,9 @@ export const Block = Node.create<IBlock>({
   renderHTML({ HTMLAttributes }) {
     const attrs: Record<string, string> = {};
     for (let [nodeAttr, HTMLAttr] of Object.entries(BlockAttributes)) {
-      attrs[HTMLAttr] = HTMLAttributes[nodeAttr];
+      if (HTMLAttributes[nodeAttr]) {
+        attrs[HTMLAttr] = HTMLAttributes[nodeAttr];
+      }
     }
 
     return [

--- a/packages/core/src/extensions/UniqueID/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID/UniqueID.ts
@@ -62,17 +62,6 @@ const UniqueID = Extension.create({
         attributes: {
           [this.options.attributeName]: {
             default: null,
-            parseHTML: (element) =>
-              element.getAttribute(`data-${this.options.attributeName}`),
-            renderHTML: (attributes) => {
-              if (!attributes[this.options.attributeName]) {
-                return {};
-              }
-              return {
-                [`data-${this.options.attributeName}`]:
-                  attributes[this.options.attributeName],
-              };
-            },
           },
         },
       },

--- a/tests/end-to-end/draghandle/draghandle.test.ts
+++ b/tests/end-to-end/draghandle/draghandle.test.ts
@@ -10,8 +10,12 @@ import {
   H_THREE_BLOCK_SELECTOR,
   H_TWO_BLOCK_SELECTOR,
   SLASH_MENU_SELECTOR,
+  TYPE_DELAY,
 } from "../../utils/const";
-import { hoverAndAddBlockFromDragHandle } from "../../utils/draghandle";
+import {
+  getDragHandleYCoord,
+  hoverAndAddBlockFromDragHandle,
+} from "../../utils/draghandle";
 import { compareDocToSnapshot, focusOnEditor } from "../../utils/editor";
 import { moveMouseOverElement } from "../../utils/mouse";
 import { executeSlashCommand } from "../../utils/slashmenu";
@@ -37,6 +41,44 @@ test.describe("Check Draghandle functionality", () => {
     await page.keyboard.type("Hover over this text");
     await moveMouseOverElement(page, H_ONE_BLOCK_SELECTOR);
     await page.waitForSelector(DRAG_HANDLE);
+  });
+
+  test("Draghandle should display next to correct block", async () => {
+    await executeSlashCommand(page, "h1");
+    await page.keyboard.type("Heading 1");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+    await executeSlashCommand(page, "h2");
+    await page.keyboard.type("Heading 2");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+    await executeSlashCommand(page, "h3");
+    await page.keyboard.type("Heading 3");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+
+    const h1y = await getDragHandleYCoord(page, H_ONE_BLOCK_SELECTOR);
+    const h2y = await getDragHandleYCoord(page, H_TWO_BLOCK_SELECTOR);
+    const h3y = await getDragHandleYCoord(page, H_THREE_BLOCK_SELECTOR);
+
+    expect(h1y < h2y && h1y < h3y && h2y < h3y).toBeTruthy();
+  });
+
+  test("Draghandle should display next to correct nested block", async () => {
+    await executeSlashCommand(page, "h1");
+    await page.keyboard.type("Heading 1");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+    await page.keyboard.press("Tab");
+    await executeSlashCommand(page, "h2");
+    await page.keyboard.type("Heading 2");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+    await page.keyboard.press("Tab");
+    await executeSlashCommand(page, "h3");
+    await page.keyboard.type("Heading 3");
+    await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
+
+    const h1y = await getDragHandleYCoord(page, H_ONE_BLOCK_SELECTOR);
+    const h2y = await getDragHandleYCoord(page, H_TWO_BLOCK_SELECTOR);
+    const h3y = await getDragHandleYCoord(page, H_THREE_BLOCK_SELECTOR);
+
+    expect(h1y < h2y && h1y < h3y && h2y < h3y).toBeTruthy();
   });
 
   // TODO: add drag and drop test - playwright dragAndDrop function not working for some reason

--- a/tests/utils/draghandle.ts
+++ b/tests/utils/draghandle.ts
@@ -1,5 +1,5 @@
 import { Page } from "@playwright/test";
-import { DRAG_HANDLE_ADD } from "./const";
+import { DRAG_HANDLE, DRAG_HANDLE_ADD } from "./const";
 import { moveMouseOverElement } from "./mouse";
 
 export async function addBlockFromDragHandle(page: Page, blockQuery: string) {
@@ -15,4 +15,11 @@ export async function hoverAndAddBlockFromDragHandle(
 ) {
   await moveMouseOverElement(page, selector);
   await addBlockFromDragHandle(page, blockQuery);
+}
+
+export async function getDragHandleYCoord(page: Page, selector: string) {
+  await moveMouseOverElement(page, selector);
+  await page.waitForSelector(DRAG_HANDLE);
+  const boundingBox = await page.locator(DRAG_HANDLE).boundingBox();
+  return boundingBox.y;
 }


### PR DESCRIPTION
This PR moves code for rendering the `id` attribute of blocks to the same place as all other block-specific attributes, while it was previously done separately as part of the UniqueId extension. This should also be a more robust fix for ensuring the `id` node attribute/`data-id` HTML attribute does not get accidentally removed from blocks in the future.