### PR TITLE
WIP: Text alignment

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -508,6 +508,7 @@ export const Block = Node.create<IBlock>({
           {
             name: "headingContent",
             attrs: {
+              textAlignment: "left",
               headingLevel: "1",
             },
           }
@@ -518,6 +519,7 @@ export const Block = Node.create<IBlock>({
           {
             name: "headingContent",
             attrs: {
+              textAlignment: "left",
               headingLevel: "2",
             },
           }
@@ -528,6 +530,7 @@ export const Block = Node.create<IBlock>({
           {
             name: "headingContent",
             attrs: {
+              textAlignment: "left",
               headingLevel: "3",
             },
           }
@@ -538,6 +541,7 @@ export const Block = Node.create<IBlock>({
           {
             name: "listItemContent",
             attrs: {
+              textAlignment: "left",
               listItemType: "unordered",
             },
           }
@@ -548,6 +552,7 @@ export const Block = Node.create<IBlock>({
           {
             name: "listItemContent",
             attrs: {
+              textAlignment: "left",
               listItemType: "ordered",
             },
           }

--- a/packages/core/src/extensions/Blocks/nodes/BlockTypes/HeadingBlock/HeadingContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockTypes/HeadingBlock/HeadingContent.ts
@@ -4,6 +4,7 @@ import styles from "../../Block.module.css";
 export type HeadingContentType = {
   name: "headingContent";
   attrs?: {
+    textAlignment: string;
     headingLevel: string;
   };
 };
@@ -15,6 +16,14 @@ export const HeadingContent = Node.create({
 
   addAttributes() {
     return {
+      textAlignment: {
+        default: "left",
+        parseHTML: (element) => element.getAttribute("align"),
+        renderHTML: (attributes) =>
+          attributes.textAlignment !== "left"
+            ? { align: attributes.textAlignment }
+            : undefined,
+      },
       headingLevel: {
         default: "1",
         // instead of "level" attributes, use "data-level"
@@ -39,6 +48,7 @@ export const HeadingContent = Node.create({
               .BNSetContentType(state.selection.from, {
                 name: "headingContent",
                 attrs: {
+                  textAlignment: "left",
                   headingLevel: level,
                 },
               })
@@ -71,7 +81,6 @@ export const HeadingContent = Node.create({
   },
 
   renderHTML({ node, HTMLAttributes }) {
-    console.log(node.attrs);
     return [
       "div",
       mergeAttributes(HTMLAttributes, {

--- a/packages/core/src/extensions/Blocks/nodes/BlockTypes/ListItemBlock/ListItemContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockTypes/ListItemBlock/ListItemContent.ts
@@ -6,6 +6,7 @@ import styles from "../../Block.module.css";
 export type ListItemContentType = {
   name: "listItemContent";
   attrs?: {
+    textAlignment: string;
     listItemType: string;
   };
 };
@@ -17,6 +18,14 @@ export const ListItemContent = Node.create({
 
   addAttributes() {
     return {
+      textAlignment: {
+        default: "right",
+        parseHTML: (element) => element.getAttribute("align"),
+        renderHTML: (attributes) =>
+          attributes.textAlignment !== "left"
+            ? { align: attributes.textAlignment }
+            : undefined,
+      },
       listItemType: {
         default: "unordered",
         parseHTML: (element) => element.getAttribute("data-list-item-type"),
@@ -48,6 +57,7 @@ export const ListItemContent = Node.create({
             .BNSetContentType(state.selection.from, {
               name: "listItemContent",
               attrs: {
+                textAlignment: "left",
                 listItemType: "unordered",
               },
             })
@@ -63,6 +73,7 @@ export const ListItemContent = Node.create({
             .BNSetContentType(state.selection.from, {
               name: "listItemContent",
               attrs: {
+                textAlignment: "left",
                 listItemType: "ordered",
               },
             })

--- a/packages/core/src/extensions/Blocks/nodes/BlockTypes/TextBlock/TextContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockTypes/TextBlock/TextContent.ts
@@ -1,15 +1,30 @@
-import { Node } from "@tiptap/core";
+import { mergeAttributes, Node } from "@tiptap/core";
 import styles from "../../Block.module.css";
 
 export type TextContentType = {
   name: "textContent";
-  attrs?: {};
+  attrs?: {
+    textAlignment: string;
+  };
 };
 
 export const TextContent = Node.create({
   name: "textContent",
   group: "blockContent",
   content: "inline*",
+
+  addAttributes() {
+    return {
+      textAlignment: {
+        default: "left",
+        parseHTML: (element) => element.getAttribute("align"),
+        renderHTML: (attributes) =>
+          attributes.textAlignment !== "left"
+            ? { align: attributes.textAlignment }
+            : { align: attributes.textAlignment },
+      },
+    };
+  },
 
   parseHTML() {
     return [
@@ -21,13 +36,13 @@ export const TextContent = Node.create({
     ];
   },
 
-  renderHTML() {
+  renderHTML({ HTMLAttributes }) {
     return [
       "div",
-      {
+      mergeAttributes(HTMLAttributes, {
         class: styles.blockContent,
         "data-content-type": this.name,
-      },
+      }),
       ["p", 0],
     ];
   },

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
@@ -8,6 +8,8 @@ export type FormattingToolbarStaticParams = {
   toggleStrike: () => void;
   setHyperlink: (url: string, text?: string) => void;
 
+  setTextAlignment: (alignment: string) => void;
+
   setBlockType: (type: BlockContentType) => void;
 };
 
@@ -19,6 +21,8 @@ export type FormattingToolbarDynamicParams = {
   hyperlinkIsActive: boolean;
   activeHyperlinkUrl: string;
   activeHyperlinkText: string;
+
+  textAlignment: string;
 
   // BlockContentType is mostly used to set a block's type, so the attr field is optional as block content types have
   // default values for attributes. However, it means that a block type's attributes field will never be undefined due to

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -13,6 +13,7 @@ import {
   FormattingToolbarStaticParams,
 } from "./FormattingToolbarFactoryTypes";
 import { BlockContentType } from "../Blocks/nodes/Block";
+import { getBlockInfoFromPos } from "../Blocks/helpers/getBlockInfoFromPos";
 
 // Same as TipTap bubblemenu plugin, but with these changes:
 // https://github.com/ueberdosis/tiptap/pull/2596/files
@@ -265,6 +266,26 @@ export class FormattingToolbarView {
         );
         this.editor.view.focus();
       },
+      setTextAlignment: (alignment: string) => {
+        const blockInfo = getBlockInfoFromPos(
+          this.editor.state.doc,
+          this.editor.state.selection.from
+        );
+        if (!blockInfo) {
+          return;
+        }
+
+        const { startPos } = blockInfo;
+
+        this.editor.view.focus();
+        this.editor.view.dispatch(
+          this.editor.state.tr.setNodeAttribute(
+            startPos,
+            "textAlignment",
+            alignment
+          )
+        );
+      },
       setBlockType: (type: BlockContentType) => {
         this.editor.view.focus();
         this.editor.commands.BNSetContentType(
@@ -289,6 +310,10 @@ export class FormattingToolbarView {
         this.editor.state.selection.from,
         this.editor.state.selection.to
       ),
+      textAlignment: getBlockInfoFromPos(
+        this.editor.state.doc,
+        this.editor.state.selection.from
+      )?.contentNode.attrs["textAlignment"],
       activeBlockType: {
         name: this.editor.state.selection.$from.node().type.name,
         attrs: this.editor.state.selection.$from.node().attrs,

--- a/packages/core/src/extensions/SlashMenu/defaultCommands.tsx
+++ b/packages/core/src/extensions/SlashMenu/defaultCommands.tsx
@@ -17,6 +17,7 @@ const defaultCommands: { [key: string]: SlashMenuItem } = {
         .BNCreateBlockOrSetContentType(range.from, {
           name: "headingContent",
           attrs: {
+            textAlignment: "left",
             headingLevel: "1",
           },
         })
@@ -39,6 +40,7 @@ const defaultCommands: { [key: string]: SlashMenuItem } = {
         .BNCreateBlockOrSetContentType(range.from, {
           name: "headingContent",
           attrs: {
+            textAlignment: "left",
             headingLevel: "2",
           },
         })
@@ -61,6 +63,7 @@ const defaultCommands: { [key: string]: SlashMenuItem } = {
         .BNCreateBlockOrSetContentType(range.from, {
           name: "headingContent",
           attrs: {
+            textAlignment: "left",
             headingLevel: "3",
           },
         })
@@ -83,6 +86,7 @@ const defaultCommands: { [key: string]: SlashMenuItem } = {
         .BNCreateBlockOrSetContentType(range.from, {
           name: "listItemContent",
           attrs: {
+            textAlignment: "left",
             listItemType: "ordered",
           },
         })
@@ -105,6 +109,7 @@ const defaultCommands: { [key: string]: SlashMenuItem } = {
         .BNCreateBlockOrSetContentType(range.from, {
           name: "listItemContent",
           attrs: {
+            textAlignment: "left",
             listItemType: "unordered",
           },
         })

--- a/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
+++ b/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
@@ -1,4 +1,8 @@
 import {
+  RiAlignCenter,
+  RiAlignJustify,
+  RiAlignLeft,
+  RiAlignRight,
   RiBold,
   RiH1,
   RiH2,
@@ -34,7 +38,11 @@ export type FormattingToolbarProps = {
   activeHyperlinkText: string;
   setHyperlink: (url: string, text?: string) => void;
 
+  textAlignment: string;
+  setTextAlignment: (textAlignment: string) => void;
+
   activeBlockType: Required<BlockContentType>;
+
   setBlockType: (type: BlockContentType) => void;
 };
 
@@ -115,7 +123,7 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
             onClick: () =>
               props.setBlockType({
                 name: "headingContent",
-                attrs: { headingLevel: "1" },
+                attrs: { textAlignment: "left", headingLevel: "1" },
               }),
             text: "Heading 1",
             icon: RiH1,
@@ -127,7 +135,7 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
             onClick: () =>
               props.setBlockType({
                 name: "headingContent",
-                attrs: { headingLevel: "2" },
+                attrs: { textAlignment: "left", headingLevel: "2" },
               }),
             text: "Heading 2",
             icon: RiH2,
@@ -139,7 +147,7 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
             onClick: () =>
               props.setBlockType({
                 name: "headingContent",
-                attrs: { headingLevel: "3" },
+                attrs: { textAlignment: "left", headingLevel: "3" },
               }),
             text: "Heading 3",
             icon: RiH3,
@@ -151,7 +159,7 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
             onClick: () =>
               props.setBlockType({
                 name: "listItemContent",
-                attrs: { listItemType: "unordered" },
+                attrs: { textAlignment: "left", listItemType: "unordered" },
               }),
             text: "Bullet List",
             icon: RiListUnordered,
@@ -163,7 +171,7 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
             onClick: () =>
               props.setBlockType({
                 name: "listItemContent",
-                attrs: { listItemType: "ordered" },
+                attrs: { textAlignment: "left", listItemType: "ordered" },
               }),
             text: "Numbered List",
             icon: RiListOrdered,
@@ -200,6 +208,31 @@ export const FormattingToolbar = (props: FormattingToolbarProps) => {
         mainTooltip="Strike-through"
         secondaryTooltip={formatKeyboardShortcut("Mod+Shift+X")}
         icon={RiStrikethrough}
+      />
+      <ToolbarButton
+        onClick={() => props.setTextAlignment("left")}
+        isSelected={props.textAlignment === "left"}
+        mainTooltip={"Align Text Left"}
+        icon={RiAlignLeft}
+      />
+      <ToolbarButton
+        onClick={() => props.setTextAlignment("center")}
+        isSelected={props.textAlignment === "center"}
+        mainTooltip={"Align Text Center"}
+        icon={RiAlignCenter}
+      />
+      <ToolbarButton
+        onClick={() => props.setTextAlignment("right")}
+        isSelected={props.textAlignment === "right"}
+        mainTooltip={"Align Text Right"}
+        icon={RiAlignRight}
+      />
+
+      <ToolbarButton
+        onClick={() => props.setTextAlignment("justify")}
+        isSelected={props.textAlignment === "justify"}
+        mainTooltip={"Justify Text"}
+        icon={RiAlignJustify}
       />
       <ToolbarButton
         onClick={() => {


### PR DESCRIPTION
The PR exposes `textAlignment: string` and `setTextAlignment: (textAlignment: string) => void' fields to the formatting toolbar factory API, which allows any implementation of the formatting toolbar to set text alignment for any given paragraph, heading, or list item block content. It also adds buttons to the React formatting toolbar implementation to do exactly this.

This PR is currently WIP as it fiddles with block content node (paragraph, heading, & list item) specs, making it likely to change based on feedback from PR #86. It would also be good to finalize PR #88 before this one, as it also includes some changes that would be beneficial here. Overall, the functionality introduced by this PR is working, it would just make more sense to merge #86 and #88 before finishing this one.