### PR TITLE
make api accessible via editor, hide tiptap initialization options

### DIFF
--- a/examples/editor/src/App.tsx
+++ b/examples/editor/src/App.tsx
@@ -7,17 +7,17 @@ type WindowWithProseMirror = Window & typeof globalThis & { ProseMirror: any };
 
 function App() {
   const editor = useBlockNote({
-    onUpdate: ({ editor }) => {
+    onUpdate: () => {
       // console.log(editor.getJSON());
-      (window as WindowWithProseMirror).ProseMirror = editor; // Give tests a way to get editor instance
     },
-    editorProps: {
-      attributes: {
-        class: styles.editor,
-        "data-test": "editor",
-      },
+    editorDOMAttributes: {
+      class: styles.editor,
+      "data-test": "editor",
     },
   });
+
+  // Give tests a way to get prosemirror instance
+  (window as WindowWithProseMirror).ProseMirror = editor?._tiptapEditor;
 
   return <BlockNoteView editor={editor} />;
 }

--- a/examples/vanilla/src/main.tsx
+++ b/examples/vanilla/src/main.tsx
@@ -17,14 +17,11 @@ const editor = new BlockNoteEditor({
     // Create an example menu for when a block is hovered
     blockSideMenuFactory,
   },
-  onUpdate: ({ editor }) => {
-    console.log(editor.getJSON());
-    (window as any).ProseMirror = editor; // Give tests a way to get editor instance
+  onUpdate: () => {
+    console.log(editor.allBlocks);
   },
-  editorProps: {
-    attributes: {
-      class: "editor",
-    },
+  editorDOMAttributes: {
+    class: "editor",
   },
 });
 

--- a/examples/vanilla/src/main.tsx
+++ b/examples/vanilla/src/main.tsx
@@ -6,7 +6,7 @@ import { hyperlinkToolbarFactory } from "./ui/hyperlinkToolbarFactory";
 import { slashMenuFactory } from "./ui/slashMenuFactory";
 
 const editor = new BlockNoteEditor({
-  element: document.getElementById("root")!,
+  parentElement: document.getElementById("root")!,
   uiFactories: {
     // Create an example formatting toolbar which just consists of a bold toggle
     formattingToolbarFactory,

--- a/packages/core/src/BlockNoteEditor.test.ts
+++ b/packages/core/src/BlockNoteEditor.test.ts
@@ -7,6 +7,6 @@ import { getBlockInfoFromPos } from "./extensions/Blocks/helpers/getBlockInfoFro
  */
 it("creates an editor", () => {
   const editor = new BlockNoteEditor({});
-  const blockInfo = getBlockInfoFromPos(editor.tiptapEditor.state.doc, 2);
+  const blockInfo = getBlockInfoFromPos(editor._tiptapEditor.state.doc, 2);
   expect(blockInfo?.contentNode.type.name).toEqual("paragraph");
 });

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -4,15 +4,14 @@ import { Editor, EditorOptions } from "@tiptap/core";
 import { Editor as EditorAPI } from "./api/Editor";
 import { getBlockNoteExtensions, UiFactories } from "./BlockNoteExtensions";
 import styles from "./editor.module.css";
-import { SlashCommand } from "./extensions/SlashMenu";
-import { defaultSlashCommands } from "./extensions/SlashMenu";
+import { defaultSlashCommands, SlashCommand } from "./extensions/SlashMenu";
 
 export type BlockNoteEditorOptions = {
   enableBlockNoteExtensions: boolean;
   disableHistoryExtension: boolean;
   uiFactories: UiFactories;
   slashCommands: SlashCommand[];
-  element: HTMLElement;
+  parentElement: HTMLElement;
   editorDOMAttributes: Record<string, string>;
   onUpdate: () => void;
   onCreate: () => void;
@@ -21,7 +20,7 @@ export type BlockNoteEditorOptions = {
   _tiptapOptions: any;
 };
 
-const blockNoteOptions = {
+const blockNoteTipTapOptions = {
   enableInputRules: true,
   enablePasteRules: true,
   enableCoreExtensions: false,
@@ -29,6 +28,10 @@ const blockNoteOptions = {
 
 export class BlockNoteEditor extends EditorAPI {
   public readonly _tiptapEditor: Editor & { contentComponent: any };
+
+  public get domElement() {
+    return this._tiptapEditor.view.dom as HTMLDivElement;
+  }
 
   constructor(options: Partial<BlockNoteEditorOptions> = {}) {
     const blockNoteExtensions = getBlockNoteExtensions({
@@ -41,7 +44,7 @@ export class BlockNoteEditor extends EditorAPI {
       : blockNoteExtensions;
 
     const tiptapOptions: EditorOptions = {
-      ...blockNoteOptions,
+      ...blockNoteTipTapOptions,
       ...options._tiptapOptions,
       onUpdate: () => {
         options.onUpdate?.();

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -28,8 +28,6 @@ const blockNoteOptions = {
 
 export class BlockNoteEditor extends EditorAPI {
   public readonly _tiptapEditor: Editor & { contentComponent: any };
-  // TODO: design where to put this
-  // public readonly api: EditorAPI;
 
   constructor(options: Partial<BlockNoteEditorOptions> = {}) {
     const blockNoteExtensions = getBlockNoteExtensions({

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -5,7 +5,7 @@ import { Editor as EditorAPI } from "./api/Editor";
 import { getBlockNoteExtensions, UiFactories } from "./BlockNoteExtensions";
 import styles from "./editor.module.css";
 import { SlashCommand } from "./extensions/SlashMenu";
-import { defaultSlashCommands } from "./extensions/SlashMenu/defaultSlashCommands";
+import { defaultSlashCommands } from "./extensions/SlashMenu";
 
 export type BlockNoteEditorOptions = {
   enableBlockNoteExtensions: boolean;
@@ -15,6 +15,7 @@ export type BlockNoteEditorOptions = {
   element: HTMLElement;
   editorDOMAttributes: Record<string, string>;
   onUpdate: () => void;
+  onCreate: () => void;
 
   // tiptap options, undocumented
   _tiptapOptions: any;
@@ -44,6 +45,9 @@ export class BlockNoteEditor extends EditorAPI {
       ...options._tiptapOptions,
       onUpdate: () => {
         options.onUpdate?.();
+      },
+      onCreate: () => {
+        options.onCreate?.();
       },
       extensions:
         options.enableBlockNoteExtensions === false

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -1,12 +1,11 @@
 import { Node, Schema } from "prosemirror-model";
-import { getBlockInfoFromPos } from "../../extensions/Blocks/helpers/getBlockInfoFromPos";
 import {
   Block,
-  BlockProps,
   blockProps,
   PartialBlock,
 } from "../../extensions/Blocks/api/blockTypes";
 import { Style, StyledText } from "../../extensions/Blocks/api/styleTypes";
+import { getBlockInfoFromPos } from "../../extensions/Blocks/helpers/getBlockInfoFromPos";
 import UniqueID from "../../extensions/UniqueID/UniqueID";
 
 export function blockToNode(block: PartialBlock, schema: Schema) {
@@ -47,7 +46,7 @@ export function blockToNode(block: PartialBlock, schema: Schema) {
   return schema.nodes["blockContainer"].create(
     {
       id: id,
-      ...block.props
+      ...block.props,
     },
     children.length > 0 ? [contentNode, groupNode] : contentNode
   );
@@ -70,11 +69,11 @@ export function getNodeById(
     if (node.type.name !== "blockContainer" || node.attrs.id !== id) {
       return true;
     }
-    console.log("grdgrdgrdgdr")
-    console.log(doc.resolve(pos).node().type.name)
-    console.log(doc.resolve(pos+ 1).node().type.name)
-    console.log(doc.resolve(pos+2).node().type.name)
-    console.log("grdgrdgrdgdr")
+    console.log("grdgrdgrdgdr");
+    console.log(doc.resolve(pos).node().type.name);
+    console.log(doc.resolve(pos + 1).node().type.name);
+    console.log(doc.resolve(pos + 2).node().type.name);
+    console.log("grdgrdgrdgdr");
 
     targetNode = node;
     posBeforeNode = pos + 1;
@@ -97,7 +96,11 @@ export function nodeToBlock(
   blockCache?: WeakMap<Node, Block>
 ): Block {
   if (node.type.name !== "blockContainer") {
-    throw Error("Node must be of type blockContainer, but is of type" + node.type.name + ".")
+    throw Error(
+      "Node must be of type blockContainer, but is of type" +
+        node.type.name +
+        "."
+    );
   }
 
   const cachedBlock = blockCache?.get(node);
@@ -112,7 +115,7 @@ export function nodeToBlock(
 
   // Only used for blocks converted from other formats.
   if (id === null) {
-    id =  UniqueID.options.generateID()
+    id = UniqueID.options.generateID();
   }
 
   const props: any = {};
@@ -128,7 +131,7 @@ export function nodeToBlock(
 
     const validAttrs = blockProps[blockInfo.contentType.name as Block["type"]];
 
-    if (validAttrs.has(attr as BlockProps)) {
+    if (validAttrs.has(attr)) {
       props[attr] = value;
     }
   }

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -69,11 +69,6 @@ export function getNodeById(
     if (node.type.name !== "blockContainer" || node.attrs.id !== id) {
       return true;
     }
-    console.log("grdgrdgrdgdr");
-    console.log(doc.resolve(pos).node().type.name);
-    console.log(doc.resolve(pos + 1).node().type.name);
-    console.log(doc.resolve(pos + 2).node().type.name);
-    console.log("grdgrdgrdgdr");
 
     targetNode = node;
     posBeforeNode = pos + 1;

--- a/packages/core/src/extensions/Blocks/api/blockTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/blockTypes.ts
@@ -47,9 +47,10 @@ export type Block =
 
 /** Define "Partial Blocks", these are for updating or creating blocks */
 export type PartialBlockTemplate<B extends Block> = B extends Block
-  ? Partial<Omit<B, "props" | "children" | "type">> & {
+  ? Partial<Omit<B, "props" | "children" | "content" | "type">> & {
       type: B["type"];
       props?: Partial<B["props"]>;
+      content?: string | B["content"];
       children?: PartialBlock[];
     }
   : never;

--- a/packages/core/src/extensions/Blocks/api/blockTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/blockTypes.ts
@@ -1,5 +1,7 @@
 import { StyledText } from "./styleTypes";
 
+/** Define the main block types **/
+
 export type BlockTemplate<
   // Type of the block.
   // Examples might include: "paragraph", "heading", or "bulletListItem".
@@ -14,23 +16,6 @@ export type BlockTemplate<
   content: StyledText[];
   children: Block[];
 };
-
-export type PartialBlockTemplate<Template> = Template extends BlockTemplate<
-  infer Type,
-  infer Props
->
-  ? {
-      id?: string;
-      type: Type;
-      props?: Partial<Props>;
-      content?: string | StyledText[];
-      children?: PartialBlock[];
-    }
-  : never;
-
-export type BlockPropsTemplate<Props> = Props extends Block["props"]
-  ? keyof Props
-  : never;
 
 export type GlobalProps = {
   backgroundColor: string;
@@ -60,20 +45,38 @@ export type Block =
   | BulletListItemBlock
   | NumberedListItemBlock;
 
-// @ts-ignore
+/** Define "Partial Blocks", these are for updating or creating blocks */
+export type PartialBlockTemplate<B extends Block> = B extends Block
+  ? Partial<Omit<B, "props" | "children" | "type">> & {
+      type: B["type"];
+      props?: Partial<B["props"]>;
+      children?: PartialBlock[];
+    }
+  : never;
+
 export type PartialBlock = PartialBlockTemplate<Block>;
 
-export type BlockProps = BlockPropsTemplate<PartialBlock["props"]>;
+export type BlockPropsTemplate<Props> = Props extends Block["props"]
+  ? keyof Props
+  : never;
 
-// TODO: Better way of doing this type guard?
+/**
+ * Expose blockProps. This is currently not very nice, but it's expected this
+ * will change anyway once we allow for custom blocks
+ */
+
 export const globalProps: Array<keyof GlobalProps> = [
   "backgroundColor",
   "textColor",
   "textAlignment",
 ];
-export const blockProps: Record<Block["type"], Set<BlockProps>> = {
+
+export const blockProps: Record<Block["type"], Set<string>> = {
   paragraph: new Set<keyof ParagraphBlock["props"]>([...globalProps]),
-  heading: new Set<keyof HeadingBlock["props"]>([...globalProps, "level"]),
+  heading: new Set<keyof HeadingBlock["props"]>([
+    ...globalProps,
+    "level" as const,
+  ]),
   numberedListItem: new Set<keyof NumberedListItemBlock["props"]>([
     ...globalProps,
   ]),

--- a/packages/core/test/__snapshots__/blockManipulation.test.ts.snap
+++ b/packages/core/test/__snapshots__/blockManipulation.test.ts.snap
@@ -12,7 +12,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
             "text": "Nested Heading 1",
           },
         ],
-        "id": 1,
+        "id": 2,
         "props": {
           "backgroundColor": "default",
           "level": "1",
@@ -28,7 +28,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
         "text": "Heading 1",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "level": "1",
@@ -47,7 +47,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
             "text": "Nested Heading 2",
           },
         ],
-        "id": 3,
+        "id": 4,
         "props": {
           "backgroundColor": "default",
           "level": "2",
@@ -63,7 +63,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
         "text": "Heading 2",
       },
     ],
-    "id": 2,
+    "id": 3,
     "props": {
       "backgroundColor": "default",
       "level": "2",
@@ -75,7 +75,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -98,7 +98,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
             "text": "Nested Heading 1",
           },
         ],
-        "id": 1,
+        "id": 2,
         "props": {
           "backgroundColor": "default",
           "level": "1",
@@ -114,7 +114,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
         "text": "Heading 1",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -132,7 +132,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
             "text": "Nested Heading 2",
           },
         ],
-        "id": 3,
+        "id": 4,
         "props": {
           "backgroundColor": "default",
           "level": "2",
@@ -148,7 +148,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
         "text": "Heading 2",
       },
     ],
-    "id": 2,
+    "id": 3,
     "props": {
       "backgroundColor": "default",
       "level": "2",
@@ -160,7 +160,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -181,7 +181,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
         "text": "Heading 1",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -192,7 +192,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete multiple blo
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -213,7 +213,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
         "text": "Paragraph",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -224,7 +224,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -247,7 +247,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
             "text": "Paragraph",
           },
         ],
-        "id": 1,
+        "id": 2,
         "props": {
           "backgroundColor": "default",
           "textAlignment": "left",
@@ -280,7 +280,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
         "text": "3",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "level": "3",
@@ -292,7 +292,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -308,7 +308,7 @@ exports[`Insert, Update, & Delete Blocks > Insert, update, & delete single block
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -324,7 +324,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -342,7 +342,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
             "text": "Nested Heading 1",
           },
         ],
-        "id": 1,
+        "id": 2,
         "props": {
           "backgroundColor": "default",
           "level": "1",
@@ -358,7 +358,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
         "text": "Heading 1",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "level": "1",
@@ -377,7 +377,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
             "text": "Nested Heading 2",
           },
         ],
-        "id": 3,
+        "id": 4,
         "props": {
           "backgroundColor": "default",
           "level": "2",
@@ -393,7 +393,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
         "text": "Heading 2",
       },
     ],
-    "id": 2,
+    "id": 3,
     "props": {
       "backgroundColor": "default",
       "level": "2",
@@ -405,7 +405,7 @@ exports[`Inserting Blocks with Different Placements > Insert after existing bloc
   {
     "children": [],
     "content": [],
-    "id": 4,
+    "id": 5,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -428,7 +428,7 @@ exports[`Inserting Blocks with Different Placements > Insert before existing blo
             "text": "Nested Heading 1",
           },
         ],
-        "id": 1,
+        "id": 2,
         "props": {
           "backgroundColor": "default",
           "level": "1",
@@ -444,7 +444,7 @@ exports[`Inserting Blocks with Different Placements > Insert before existing blo
         "text": "Heading 1",
       },
     ],
-    "id": 0,
+    "id": 1,
     "props": {
       "backgroundColor": "default",
       "level": "1",
@@ -463,7 +463,7 @@ exports[`Inserting Blocks with Different Placements > Insert before existing blo
             "text": "Nested Heading 2",
           },
         ],
-        "id": 3,
+        "id": 4,
         "props": {
           "backgroundColor": "default",
           "level": "2",
@@ -479,7 +479,7 @@ exports[`Inserting Blocks with Different Placements > Insert before existing blo
         "text": "Heading 2",
       },
     ],
-    "id": 2,
+    "id": 3,
     "props": {
       "backgroundColor": "default",
       "level": "2",
@@ -491,7 +491,7 @@ exports[`Inserting Blocks with Different Placements > Insert before existing blo
   {
     "children": [],
     "content": [],
-    "id": null,
+    "id": 0,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",

--- a/packages/core/test/__snapshots__/formatConversions.test.ts.snap
+++ b/packages/core/test/__snapshots__/formatConversions.test.ts.snap
@@ -731,7 +731,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested HTML to
         "text": "Heading",
       },
     ],
-    "id": null,
+    "id": 27,
     "props": {
       "backgroundColor": "default",
       "level": "1",
@@ -748,7 +748,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested HTML to
         "text": "Paragraph",
       },
     ],
-    "id": null,
+    "id": 28,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -764,7 +764,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested HTML to
         "text": "Bullet List Item",
       },
     ],
-    "id": null,
+    "id": 29,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -780,7 +780,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested HTML to
         "text": "Numbered List Item",
       },
     ],
-    "id": null,
+    "id": 30,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -801,7 +801,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested Markdow
         "text": "Heading",
       },
     ],
-    "id": null,
+    "id": 27,
     "props": {
       "backgroundColor": "default",
       "level": "1",
@@ -818,7 +818,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested Markdow
         "text": "Paragraph",
       },
     ],
-    "id": null,
+    "id": 28,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -834,7 +834,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested Markdow
         "text": "Bullet List Item",
       },
     ],
-    "id": null,
+    "id": 29,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -850,7 +850,7 @@ exports[`Non-Nested Block/HTML/Markdown Conversions > Convert non-nested Markdow
         "text": "Numbered List Item",
       },
     ],
-    "id": null,
+    "id": 30,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -951,7 +951,7 @@ exports[`Styled Block/HTML/Markdown Conversions > Convert styled HTML to blocks 
         "text": "Multiple",
       },
     ],
-    "id": null,
+    "id": 27,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",
@@ -1016,7 +1016,7 @@ exports[`Styled Block/HTML/Markdown Conversions > Convert styled Markdown to blo
         "text": "Multiple",
       },
     ],
-    "id": null,
+    "id": 27,
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",

--- a/packages/core/test/__snapshots__/nodeConversions.test.ts.snap
+++ b/packages/core/test/__snapshots__/nodeConversions.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex block to node 1`
 {
   "attrs": {
     "backgroundColor": "blue",
-    "id": null,
+    "id": 4,
     "textColor": "yellow",
   },
   "content": [
@@ -46,7 +46,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex block to node 1`
         {
           "attrs": {
             "backgroundColor": "red",
-            "id": null,
+            "id": 5,
             "textColor": "default",
           },
           "content": [
@@ -68,7 +68,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex block to node 1`
         {
           "attrs": {
             "backgroundColor": "default",
-            "id": null,
+            "id": 6,
             "textColor": "default",
           },
           "content": [
@@ -100,7 +100,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex node to block 1`
           "text": "Paragraph",
         },
       ],
-      "id": null,
+      "id": 2,
       "props": {
         "backgroundColor": "red",
         "textAlignment": "left",
@@ -111,7 +111,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex node to block 1`
     {
       "children": [],
       "content": [],
-      "id": null,
+      "id": 3,
       "props": {
         "backgroundColor": "default",
         "textAlignment": "left",
@@ -148,7 +148,7 @@ exports[`Complex ProseMirror Node Conversions > Convert complex node to block 1`
       "text": "2",
     },
   ],
-  "id": null,
+  "id": 1,
   "props": {
     "backgroundColor": "blue",
     "level": "2",
@@ -163,7 +163,7 @@ exports[`Simple ProseMirror Node Conversions > Convert simple block to node 1`] 
 {
   "attrs": {
     "backgroundColor": "default",
-    "id": null,
+    "id": 4,
     "textColor": "default",
   },
   "content": [
@@ -182,7 +182,7 @@ exports[`Simple ProseMirror Node Conversions > Convert simple node to block 1`] 
 {
   "children": [],
   "content": [],
-  "id": null,
+  "id": 0,
   "props": {
     "backgroundColor": "default",
     "textAlignment": "left",

--- a/packages/core/test/blockManipulation.test.ts
+++ b/packages/core/test/blockManipulation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { BlockNoteEditor, Editor, Block, PartialBlock } from "../src";
+import { Block, BlockNoteEditor, PartialBlock } from "../src";
 
 const singleBlock: PartialBlock = {
   type: "paragraph",
@@ -51,16 +51,15 @@ afterEach(() => {
 
 describe("Inserting Blocks with Different Placements", () => {
   function insert(placement: "before" | "nested" | "after"): Block[] {
-    const editor = new BlockNoteEditor().tiptapEditor;
-    const editorAPI = new Editor(editor);
+    const editor = new BlockNoteEditor();
     (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS =
       (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS || {};
 
-    const existingBlock = editorAPI.allBlocks[0];
+    const existingBlock = editor.allBlocks[0];
 
-    editorAPI.insertBlocks(multipleBlocks, existingBlock, placement);
+    editor.insertBlocks(multipleBlocks, existingBlock, placement);
 
-    return editorAPI.allBlocks;
+    return editor.allBlocks;
   }
 
   it("Insert before existing block", async () => {
@@ -84,18 +83,17 @@ describe("Inserting Blocks with Different Placements", () => {
 
 describe("Insert, Update, & Delete Blocks", () => {
   it("Insert, update, & delete single block", async () => {
-    const editor = new BlockNoteEditor().tiptapEditor;
-    const editorAPI = new Editor(editor);
+    const editor = new BlockNoteEditor();
 
-    const existingBlock = editorAPI.allBlocks[0];
+    const existingBlock = editor.allBlocks[0];
 
-    editorAPI.insertBlocks([singleBlock], existingBlock);
+    editor.insertBlocks([singleBlock], existingBlock);
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
 
-    const newBlock = editorAPI.allBlocks[0];
+    const newBlock = editor.allBlocks[0];
 
-    editorAPI.updateBlock(newBlock, {
+    editor.updateBlock(newBlock, {
       type: "heading",
       props: {
         textAlignment: "right",
@@ -128,37 +126,36 @@ describe("Insert, Update, & Delete Blocks", () => {
       children: [singleBlock],
     });
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
 
-    const updatedBlock = editorAPI.allBlocks[0];
+    const updatedBlock = editor.allBlocks[0];
 
-    editorAPI.removeBlocks([updatedBlock]);
+    editor.removeBlocks([updatedBlock]);
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
   });
 
   it("Insert, update, & delete multiple blocks", async () => {
-    const editor = new BlockNoteEditor().tiptapEditor;
-    const editorAPI = new Editor(editor);
+    const editor = new BlockNoteEditor();
 
-    const existingBlock = editorAPI.allBlocks[0];
+    const existingBlock = editor.allBlocks[0];
 
-    editorAPI.insertBlocks(multipleBlocks, existingBlock);
+    editor.insertBlocks(multipleBlocks, existingBlock);
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
 
-    const newBlock = editorAPI.allBlocks[0];
+    const newBlock = editor.allBlocks[0];
 
-    editorAPI.updateBlock(newBlock, {
+    editor.updateBlock(newBlock, {
       type: "paragraph",
     });
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
 
-    const updatedBlocks = editorAPI.allBlocks.slice(0, 2);
+    const updatedBlocks = editor.allBlocks.slice(0, 2);
 
-    editorAPI.removeBlocks([updatedBlocks[0].children[0], updatedBlocks[1]]);
+    editor.removeBlocks([updatedBlocks[0].children[0], updatedBlocks[1]]);
 
-    expect(editorAPI.allBlocks).toMatchSnapshot();
+    expect(editor.allBlocks).toMatchSnapshot();
   });
 });

--- a/packages/core/test/blockManipulation.test.ts
+++ b/packages/core/test/blockManipulation.test.ts
@@ -1,80 +1,111 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Block, BlockNoteEditor, PartialBlock } from "../src";
 
-const singleBlock: PartialBlock = {
-  type: "paragraph",
-  content: "Paragraph",
-};
+let editor: BlockNoteEditor;
+let ready = false;
+function waitForEditor() {
+  const poll = (resolve) => {
+    if(ready) {
+      resolve();
+    } else {
+      setTimeout(() => poll(resolve));
+    }
+  }
 
-const multipleBlocks: PartialBlock[] = [
-  {
-    type: "heading",
-    props: {
-      level: "1",
-    },
-    content: "Heading 1",
-    children: [
-      {
-        type: "heading",
-        props: {
-          level: "1",
-        },
-        content: "Nested Heading 1",
-      },
-    ],
-  },
-  {
-    type: "heading",
-    props: {
-      level: "2",
-    },
-    content: "Heading 2",
-    children: [
-      {
-        type: "heading",
-        props: {
-          level: "2",
-        },
-        content: "Nested Heading 2",
-      },
-    ],
-  },
-];
+  return new Promise<void>(poll);
+}
+
+let singleBlock: PartialBlock;
+
+let multipleBlocks: PartialBlock[];
+
+let insert: (placement: "before" | "nested" | "after") => Block[];
 
 beforeEach(() => {
   (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS = {};
-});
 
-afterEach(() => {
-  delete (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS;
-});
+  editor = new BlockNoteEditor({
+    onCreate: () => {
+      ready = true;
+    }
+  });
 
-describe("Inserting Blocks with Different Placements", () => {
-  function insert(placement: "before" | "nested" | "after"): Block[] {
-    const editor = new BlockNoteEditor();
-    (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS =
-      (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS || {};
+  singleBlock = {
+    type: "paragraph",
+    content: "Paragraph",
+  };
 
+  multipleBlocks = [
+    {
+      type: "heading",
+      props: {
+        level: "1",
+      },
+      content: "Heading 1",
+      children: [
+        {
+          type: "heading",
+          props: {
+            level: "1",
+          },
+          content: "Nested Heading 1",
+        },
+      ],
+    },
+    {
+      type: "heading",
+      props: {
+        level: "2",
+      },
+      content: "Heading 2",
+      children: [
+        {
+          type: "heading",
+          props: {
+            level: "2",
+          },
+          content: "Nested Heading 2",
+        },
+      ],
+    },
+  ];
+
+  insert = (placement) => {
     const existingBlock = editor.allBlocks[0];
-
     editor.insertBlocks(multipleBlocks, existingBlock, placement);
 
     return editor.allBlocks;
   }
+});
 
+afterEach(() => {
+  ready = false;
+  editor._tiptapEditor.destroy()
+  editor = undefined;
+
+  delete (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS;
+});
+
+describe("Inserting Blocks with Different Placements", () => {
   it("Insert before existing block", async () => {
-    const output = insert("before");
+    await waitForEditor()
+
+    const output = insert("before")
 
     expect(output).toMatchSnapshot();
   });
 
   it("Insert nested inside existing block", async () => {
+    await waitForEditor()
+
     const output = insert("nested");
 
     expect(output).toMatchSnapshot();
   });
 
   it("Insert after existing block", async () => {
+    await waitForEditor()
+
     const output = insert("after");
 
     expect(output).toMatchSnapshot();
@@ -83,16 +114,14 @@ describe("Inserting Blocks with Different Placements", () => {
 
 describe("Insert, Update, & Delete Blocks", () => {
   it("Insert, update, & delete single block", async () => {
-    const editor = new BlockNoteEditor();
+    await waitForEditor()
 
     const existingBlock = editor.allBlocks[0];
-
     editor.insertBlocks([singleBlock], existingBlock);
 
     expect(editor.allBlocks).toMatchSnapshot();
 
     const newBlock = editor.allBlocks[0];
-
     editor.updateBlock(newBlock, {
       type: "heading",
       props: {
@@ -129,23 +158,20 @@ describe("Insert, Update, & Delete Blocks", () => {
     expect(editor.allBlocks).toMatchSnapshot();
 
     const updatedBlock = editor.allBlocks[0];
-
     editor.removeBlocks([updatedBlock]);
 
     expect(editor.allBlocks).toMatchSnapshot();
   });
 
   it("Insert, update, & delete multiple blocks", async () => {
-    const editor = new BlockNoteEditor();
+    await waitForEditor()
 
     const existingBlock = editor.allBlocks[0];
-
     editor.insertBlocks(multipleBlocks, existingBlock);
 
     expect(editor.allBlocks).toMatchSnapshot();
 
     const newBlock = editor.allBlocks[0];
-
     editor.updateBlock(newBlock, {
       type: "paragraph",
     });
@@ -153,7 +179,6 @@ describe("Insert, Update, & Delete Blocks", () => {
     expect(editor.allBlocks).toMatchSnapshot();
 
     const updatedBlocks = editor.allBlocks.slice(0, 2);
-
     editor.removeBlocks([updatedBlocks[0].children[0], updatedBlocks[1]]);
 
     expect(editor.allBlocks).toMatchSnapshot();

--- a/packages/core/test/blockManipulation.test.ts
+++ b/packages/core/test/blockManipulation.test.ts
@@ -4,15 +4,14 @@ import { Block, BlockNoteEditor, PartialBlock } from "../src";
 let editor: BlockNoteEditor;
 let ready = false;
 function waitForEditor() {
-  const poll = (resolve) => {
-    if(ready) {
+  // wait for create event on editor,
+  // this is necessary because otherwise UniqueId.create hasn't been called yet, and
+  // blocks would have "null" as their id
+  return new Promise<void>((resolve) => {
+    editor._tiptapEditor.on("create", () => {
       resolve();
-    } else {
-      setTimeout(() => poll(resolve));
-    }
-  }
-
-  return new Promise<void>(poll);
+    });
+  });
 }
 
 let singleBlock: PartialBlock;
@@ -27,7 +26,7 @@ beforeEach(() => {
   editor = new BlockNoteEditor({
     onCreate: () => {
       ready = true;
-    }
+    },
   });
 
   singleBlock = {
@@ -75,12 +74,12 @@ beforeEach(() => {
     editor.insertBlocks(multipleBlocks, existingBlock, placement);
 
     return editor.allBlocks;
-  }
+  };
 });
 
 afterEach(() => {
   ready = false;
-  editor._tiptapEditor.destroy()
+  editor._tiptapEditor.destroy();
   editor = undefined;
 
   delete (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS;
@@ -88,15 +87,15 @@ afterEach(() => {
 
 describe("Inserting Blocks with Different Placements", () => {
   it("Insert before existing block", async () => {
-    await waitForEditor()
+    await waitForEditor();
 
-    const output = insert("before")
+    const output = insert("before");
 
     expect(output).toMatchSnapshot();
   });
 
   it("Insert nested inside existing block", async () => {
-    await waitForEditor()
+    await waitForEditor();
 
     const output = insert("nested");
 
@@ -104,7 +103,7 @@ describe("Inserting Blocks with Different Placements", () => {
   });
 
   it("Insert after existing block", async () => {
-    await waitForEditor()
+    await waitForEditor();
 
     const output = insert("after");
 
@@ -114,7 +113,7 @@ describe("Inserting Blocks with Different Placements", () => {
 
 describe("Insert, Update, & Delete Blocks", () => {
   it("Insert, update, & delete single block", async () => {
-    await waitForEditor()
+    await waitForEditor();
 
     const existingBlock = editor.allBlocks[0];
     editor.insertBlocks([singleBlock], existingBlock);
@@ -164,7 +163,7 @@ describe("Insert, Update, & Delete Blocks", () => {
   });
 
   it("Insert, update, & delete multiple blocks", async () => {
-    await waitForEditor()
+    await waitForEditor();
 
     const existingBlock = editor.allBlocks[0];
     editor.insertBlocks(multipleBlocks, existingBlock);

--- a/packages/core/test/formatConversions.test.ts
+++ b/packages/core/test/formatConversions.test.ts
@@ -1,11 +1,11 @@
+import { PartialBlock } from "@blocknote/core";
 import { describe, expect, it } from "vitest";
-import { Block, BlockNoteEditor, Editor } from "../src";
+import { BlockNoteEditor } from "../src";
 
-const editorAPI = new Editor(new BlockNoteEditor().tiptapEditor);
+const editorAPI = new BlockNoteEditor();
 
-const nonNestedBlocks: Block[] = [
+const nonNestedBlocks: PartialBlock[] = [
   {
-    id: null,
     type: "heading",
     props: {
       backgroundColor: "default",
@@ -22,7 +22,6 @@ const nonNestedBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "paragraph",
     props: {
       backgroundColor: "default",
@@ -38,7 +37,6 @@ const nonNestedBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "bulletListItem",
     props: {
       backgroundColor: "default",
@@ -54,7 +52,6 @@ const nonNestedBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "numberedListItem",
     props: {
       backgroundColor: "default",
@@ -108,9 +105,8 @@ describe("Non-Nested Block/HTML/Markdown Conversions", () => {
   });
 });
 
-const nestedBlocks: Block[] = [
+const nestedBlocks: PartialBlock[] = [
   {
-    id: null,
     type: "heading",
     props: {
       backgroundColor: "default",
@@ -126,7 +122,6 @@ const nestedBlocks: Block[] = [
     ],
     children: [
       {
-        id: null,
         type: "paragraph",
         props: {
           backgroundColor: "default",
@@ -141,7 +136,6 @@ const nestedBlocks: Block[] = [
         ],
         children: [
           {
-            id: null,
             type: "bulletListItem",
             props: {
               backgroundColor: "default",
@@ -156,7 +150,6 @@ const nestedBlocks: Block[] = [
             ],
             children: [
               {
-                id: null,
                 type: "numberedListItem",
                 props: {
                   backgroundColor: "default",
@@ -216,9 +209,8 @@ describe("Nested Block/HTML/Markdown Conversions", () => {
   // });
 });
 
-const styledBlocks: Block[] = [
+const styledBlocks: PartialBlock[] = [
   {
-    id: null,
     type: "paragraph",
     props: {
       backgroundColor: "default",
@@ -332,9 +324,8 @@ describe("Styled Block/HTML/Markdown Conversions", () => {
   });
 });
 
-const complexBlocks: Block[] = [
+const complexBlocks: PartialBlock[] = [
   {
-    id: null,
     type: "heading",
     props: {
       backgroundColor: "red",
@@ -350,7 +341,6 @@ const complexBlocks: Block[] = [
     ],
     children: [
       {
-        id: null,
         type: "heading",
         props: {
           backgroundColor: "orange",
@@ -366,7 +356,6 @@ const complexBlocks: Block[] = [
         ],
         children: [
           {
-            id: null,
             type: "heading",
             props: {
               backgroundColor: "yellow",
@@ -387,7 +376,6 @@ const complexBlocks: Block[] = [
     ],
   },
   {
-    id: null,
     type: "paragraph",
     props: {
       backgroundColor: "default",
@@ -416,7 +404,6 @@ const complexBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "paragraph",
     props: {
       backgroundColor: "default",
@@ -454,7 +441,6 @@ const complexBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "paragraph",
     props: {
       backgroundColor: "default",
@@ -492,7 +478,6 @@ const complexBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "bulletListItem",
     props: {
       backgroundColor: "default",
@@ -508,7 +493,6 @@ const complexBlocks: Block[] = [
     children: [],
   },
   {
-    id: null,
     type: "bulletListItem",
     props: {
       backgroundColor: "default",
@@ -523,7 +507,6 @@ const complexBlocks: Block[] = [
     ],
     children: [
       {
-        id: null,
         type: "bulletListItem",
         props: {
           backgroundColor: "default",
@@ -538,7 +521,6 @@ const complexBlocks: Block[] = [
         ],
         children: [
           {
-            id: null,
             type: "bulletListItem",
             props: {
               backgroundColor: "default",
@@ -554,7 +536,6 @@ const complexBlocks: Block[] = [
             children: [],
           },
           {
-            id: null,
             type: "paragraph",
             props: {
               backgroundColor: "default",
@@ -570,7 +551,6 @@ const complexBlocks: Block[] = [
             children: [],
           },
           {
-            id: null,
             type: "numberedListItem",
             props: {
               backgroundColor: "default",
@@ -586,7 +566,6 @@ const complexBlocks: Block[] = [
             children: [],
           },
           {
-            id: null,
             type: "numberedListItem",
             props: {
               backgroundColor: "default",
@@ -602,7 +581,6 @@ const complexBlocks: Block[] = [
             children: [],
           },
           {
-            id: null,
             type: "numberedListItem",
             props: {
               backgroundColor: "default",
@@ -617,7 +595,6 @@ const complexBlocks: Block[] = [
             ],
             children: [
               {
-                id: null,
                 type: "numberedListItem",
                 props: {
                   backgroundColor: "default",
@@ -635,7 +612,6 @@ const complexBlocks: Block[] = [
             ],
           },
           {
-            id: null,
             type: "bulletListItem",
             props: {
               backgroundColor: "default",
@@ -653,7 +629,6 @@ const complexBlocks: Block[] = [
         ],
       },
       {
-        id: null,
         type: "bulletListItem",
         props: {
           backgroundColor: "default",
@@ -671,7 +646,6 @@ const complexBlocks: Block[] = [
     ],
   },
   {
-    id: null,
     type: "bulletListItem",
     props: {
       backgroundColor: "default",

--- a/packages/core/test/formatConversions.test.ts
+++ b/packages/core/test/formatConversions.test.ts
@@ -1,76 +1,100 @@
-import { PartialBlock } from "@blocknote/core";
-import { describe, expect, it } from "vitest";
+import {Block} from "@blocknote/core";
+import {afterEach, beforeEach, describe, expect, it} from "vitest";
 import { BlockNoteEditor } from "../src";
+import UniqueID from "../src/extensions/UniqueID/UniqueID";
 
-const editorAPI = new BlockNoteEditor();
+let editor: BlockNoteEditor;
 
-const nonNestedBlocks: PartialBlock[] = [
-  {
-    type: "heading",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-      level: "1",
-    },
-    content: [
-      {
-        text: "Heading",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "paragraph",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Paragraph",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "bulletListItem",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Bullet List Item",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "numberedListItem",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Numbered List Item",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-];
+let nonNestedBlocks: Block[];
+let nonNestedHTML: string;
+let nonNestedMarkdown: string;
 
-const nonNestedHTML: string = `<h1>Heading</h1><p>Paragraph</p><ul><li><p>Bullet List Item</p></li></ul><ol><li><p>Numbered List Item</p></li></ol>`;
+let nestedBlocks: Block[];
+// let nestedHTML: string;
+// let nestedMarkdown: string;
 
-const nonNestedMarkdown: string = `# Heading
+let styledBlocks: Block[];
+let styledHTML: string;
+let styledMarkdown: string;
+
+let complexBlocks: Block[];
+// let complexHTML: string;
+// let complexMarkdown: string;
+
+beforeEach(() => {
+  (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS = {};
+
+  editor = new BlockNoteEditor();
+
+  nonNestedBlocks = [
+    {
+      id: UniqueID.options.generateID(),
+      type: "heading",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+        level: "1",
+      },
+      content: [
+        {
+          text: "Heading",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Paragraph",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "bulletListItem",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Bullet List Item",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "numberedListItem",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Numbered List Item",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+  ];
+  nonNestedHTML = `<h1>Heading</h1><p>Paragraph</p><ul><li><p>Bullet List Item</p></li></ul><ol><li><p>Numbered List Item</p></li></ol>`;
+  nonNestedMarkdown = `# Heading
 
 Paragraph
 
@@ -79,102 +103,78 @@ Paragraph
 1.  Numbered List Item
 `;
 
-describe("Non-Nested Block/HTML/Markdown Conversions", () => {
-  it("Convert non-nested blocks to HTML", async () => {
-    const output = await editorAPI.blocksToHTML(nonNestedBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert non-nested blocks to Markdown", async () => {
-    const output = await editorAPI.blocksToMarkdown(nonNestedBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert non-nested HTML to blocks", async () => {
-    const output = await editorAPI.HTMLToBlocks(nonNestedHTML);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert non-nested Markdown to blocks", async () => {
-    const output = await editorAPI.markdownToBlocks(nonNestedMarkdown);
-
-    expect(output).toMatchSnapshot();
-  });
-});
-
-const nestedBlocks: PartialBlock[] = [
-  {
-    type: "heading",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-      level: "1",
-    },
-    content: [
-      {
-        text: "Heading",
-        styles: [],
+  nestedBlocks = [
+    {
+      id: UniqueID.options.generateID(),
+      type: "heading",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+        level: "1",
       },
-    ],
-    children: [
-      {
-        type: "paragraph",
-        props: {
-          backgroundColor: "default",
-          textColor: "default",
-          textAlignment: "left",
+      content: [
+        {
+          text: "Heading",
+          styles: [],
         },
-        content: [
-          {
-            text: "Paragraph",
-            styles: [],
+      ],
+      children: [
+        {
+          id: UniqueID.options.generateID(),
+          type: "paragraph",
+          props: {
+            backgroundColor: "default",
+            textColor: "default",
+            textAlignment: "left",
           },
-        ],
-        children: [
-          {
-            type: "bulletListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
+          content: [
+            {
+              text: "Paragraph",
+              styles: [],
             },
-            content: [
-              {
-                text: "Bullet List Item",
-                styles: [],
+          ],
+          children: [
+            {
+              id: UniqueID.options.generateID(),
+              type: "bulletListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
               },
-            ],
-            children: [
-              {
-                type: "numberedListItem",
-                props: {
-                  backgroundColor: "default",
-                  textColor: "default",
-                  textAlignment: "left",
+              content: [
+                {
+                  text: "Bullet List Item",
+                  styles: [],
                 },
-                content: [
-                  {
-                    text: "Numbered List Item",
-                    styles: [],
+              ],
+              children: [
+                {
+                  id: UniqueID.options.generateID(),
+                  type: "numberedListItem",
+                  props: {
+                    backgroundColor: "default",
+                    textColor: "default",
+                    textAlignment: "left",
                   },
-                ],
-                children: [],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  },
-];
-
-// const nestedHTML: string = `<h1>Heading</h1><p>Paragraph</p><ul><li><p>Bullet List Item</p><ol><li><p>Numbered List Item</p></li></ol></li></ul>`;
-//
-// const nestedMarkdown: string = `# Heading
+                  content: [
+                    {
+                      text: "Numbered List Item",
+                      styles: [],
+                    },
+                  ],
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ];
+// nestedHTML = `<h1>Heading</h1><p>Paragraph</p><ul><li><p>Bullet List Item</p><ol><li><p>Numbered List Item</p></li></ol></li></ul>`;
+// nestedMarkdown = `# Heading
 //
 // Paragraph
 //
@@ -183,488 +183,452 @@ const nestedBlocks: PartialBlock[] = [
 //     1.  Numbered List Item
 // `;
 
-describe("Nested Block/HTML/Markdown Conversions", () => {
-  it("Convert nested blocks to HTML", async () => {
-    const output = await editorAPI.blocksToHTML(nestedBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert nested blocks to Markdown", async () => {
-    const output = await editorAPI.blocksToMarkdown(nestedBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-  // // Failing due to nested block parsing bug.
-  // it("Convert nested HTML to blocks", async () => {
-  //   const output = await editorAPI.HTMLToBlocks(nestedHTML);
-  //
-  //   expect(output).toMatchSnapshot();
-  // });
-  // // Failing due to nested block parsing bug.
-  // it("Convert nested Markdown to blocks", async () => {
-  //   const output = await editorAPI.markdownToBlocks(nestedMarkdown);
-  //
-  //   expect(output).toMatchSnapshot();
-  // });
-});
-
-const styledBlocks: PartialBlock[] = [
-  {
-    type: "paragraph",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Bold",
-        styles: [
-          {
-            type: "bold",
-            props: {},
-          },
-        ],
+  styledBlocks = [
+    {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
       },
-      {
-        text: "Italic",
-        styles: [
-          {
-            type: "italic",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "Underline",
-        styles: [
-          {
-            type: "underline",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "Strikethrough",
-        styles: [
-          {
-            type: "strike",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "TextColor",
-        styles: [
-          {
-            type: "textColor",
-            props: {
-              color: "red",
+      content: [
+        {
+          text: "Bold",
+          styles: [
+            {
+              type: "bold",
+              props: {},
             },
-          },
-        ],
-      },
-      {
-        text: "BackgroundColor",
-        styles: [
-          {
-            type: "backgroundColor",
-            props: {
-              color: "red",
-            },
-          },
-        ],
-      },
-      {
-        text: "Multiple",
-        styles: [
-          {
-            type: "bold",
-            props: {},
-          },
-          {
-            type: "italic",
-            props: {},
-          },
-        ],
-      },
-    ],
-    children: [],
-  },
-];
-
-const styledHTML: string = `<p><strong>Bold</strong><em>Italic</em><u>Underline</u><s>Strikethrough</s><span data-text-color="red">TextColor</span><span data-background-color="red">BackgroundColor</span><strong><em>Multiple</em></strong></p>`;
-
-const styledMarkdown: string = `**Bold***Italic*Underline~~Strikethrough~~TextColorBackgroundColor***Multiple***`;
-
-describe("Styled Block/HTML/Markdown Conversions", () => {
-  it("Convert styled blocks to HTML", async () => {
-    const output = await editorAPI.blocksToHTML(styledBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert styled blocks to Markdown", async () => {
-    const output = await editorAPI.blocksToMarkdown(styledBlocks);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert styled HTML to blocks", async () => {
-    const output = await editorAPI.HTMLToBlocks(styledHTML);
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it("Convert styled Markdown to blocks", async () => {
-    const output = await editorAPI.markdownToBlocks(styledMarkdown);
-
-    expect(output).toMatchSnapshot();
-  });
-});
-
-const complexBlocks: PartialBlock[] = [
-  {
-    type: "heading",
-    props: {
-      backgroundColor: "red",
-      textColor: "yellow",
-      textAlignment: "right",
-      level: "1",
-    },
-    content: [
-      {
-        text: "Heading 1",
-        styles: [],
-      },
-    ],
-    children: [
-      {
-        type: "heading",
-        props: {
-          backgroundColor: "orange",
-          textColor: "orange",
-          textAlignment: "center",
-          level: "2",
+          ],
         },
-        content: [
-          {
-            text: "Heading 2",
-            styles: [],
-          },
-        ],
-        children: [
-          {
-            type: "heading",
-            props: {
-              backgroundColor: "yellow",
-              textColor: "red",
-              textAlignment: "left",
-              level: "3",
+        {
+          text: "Italic",
+          styles: [
+            {
+              type: "italic",
+              props: {},
             },
-            content: [
-              {
-                text: "Heading 3",
-                styles: [],
-              },
-            ],
-            children: [],
-          },
-        ],
-      },
-    ],
-  },
-  {
-    type: "paragraph",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Paragraph",
-        styles: [
-          {
-            type: "textColor",
-            props: {
-              color: "purple",
-            },
-          },
-          {
-            type: "backgroundColor",
-            props: {
-              color: "green",
-            },
-          },
-        ],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "paragraph",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "P",
-        styles: [],
-      },
-      {
-        text: "ara",
-        styles: [
-          {
-            type: "bold",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "grap",
-        styles: [
-          {
-            type: "italic",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "h",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "paragraph",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "P",
-        styles: [],
-      },
-      {
-        text: "ara",
-        styles: [
-          {
-            type: "underline",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "grap",
-        styles: [
-          {
-            type: "strike",
-            props: {},
-          },
-        ],
-      },
-      {
-        text: "h",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "bulletListItem",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Bullet List Item",
-        styles: [],
-      },
-    ],
-    children: [],
-  },
-  {
-    type: "bulletListItem",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
-    },
-    content: [
-      {
-        text: "Bullet List Item",
-        styles: [],
-      },
-    ],
-    children: [
-      {
-        type: "bulletListItem",
-        props: {
-          backgroundColor: "default",
-          textColor: "default",
-          textAlignment: "left",
+          ],
         },
-        content: [
-          {
-            text: "Bullet List Item",
-            styles: [],
-          },
-        ],
-        children: [
-          {
-            type: "bulletListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
+        {
+          text: "Underline",
+          styles: [
+            {
+              type: "underline",
+              props: {},
             },
-            content: [
-              {
-                text: "Bullet List Item",
-                styles: [],
-              },
-            ],
-            children: [],
-          },
-          {
-            type: "paragraph",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
+          ],
+        },
+        {
+          text: "Strikethrough",
+          styles: [
+            {
+              type: "strike",
+              props: {},
             },
-            content: [
-              {
-                text: "Paragraph",
-                styles: [],
+          ],
+        },
+        {
+          text: "TextColor",
+          styles: [
+            {
+              type: "textColor",
+              props: {
+                color: "red",
               },
-            ],
-            children: [],
-          },
-          {
-            type: "numberedListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
             },
-            content: [
-              {
-                text: "Numbered List Item",
-                styles: [],
+          ],
+        },
+        {
+          text: "BackgroundColor",
+          styles: [
+            {
+              type: "backgroundColor",
+              props: {
+                color: "red",
               },
-            ],
-            children: [],
-          },
-          {
-            type: "numberedListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
             },
-            content: [
-              {
-                text: "Numbered List Item",
-                styles: [],
-              },
-            ],
-            children: [],
-          },
-          {
-            type: "numberedListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
+          ],
+        },
+        {
+          text: "Multiple",
+          styles: [
+            {
+              type: "bold",
+              props: {},
             },
-            content: [
-              {
-                text: "Numbered List Item",
-                styles: [],
+            {
+              type: "italic",
+              props: {},
+            },
+          ],
+        },
+      ],
+      children: [],
+    },
+  ];
+  styledHTML = `<p><strong>Bold</strong><em>Italic</em><u>Underline</u><s>Strikethrough</s><span data-text-color="red">TextColor</span><span data-background-color="red">BackgroundColor</span><strong><em>Multiple</em></strong></p>`;
+  styledMarkdown = `**Bold***Italic*Underline~~Strikethrough~~TextColorBackgroundColor***Multiple***`;
+
+  complexBlocks = [
+    {
+      id: UniqueID.options.generateID(),
+      type: "heading",
+      props: {
+        backgroundColor: "red",
+        textColor: "yellow",
+        textAlignment: "right",
+        level: "1",
+      },
+      content: [
+        {
+          text: "Heading 1",
+          styles: [],
+        },
+      ],
+      children: [
+        {
+          id: UniqueID.options.generateID(),
+          type: "heading",
+          props: {
+            backgroundColor: "orange",
+            textColor: "orange",
+            textAlignment: "center",
+            level: "2",
+          },
+          content: [
+            {
+              text: "Heading 2",
+              styles: [],
+            },
+          ],
+          children: [
+            {
+              id: UniqueID.options.generateID(),
+              type: "heading",
+              props: {
+                backgroundColor: "yellow",
+                textColor: "red",
+                textAlignment: "left",
+                level: "3",
               },
-            ],
-            children: [
-              {
-                type: "numberedListItem",
-                props: {
-                  backgroundColor: "default",
-                  textColor: "default",
-                  textAlignment: "left",
+              content: [
+                {
+                  text: "Heading 3",
+                  styles: [],
                 },
-                content: [
-                  {
-                    text: "Numbered List Item",
-                    styles: [],
-                  },
-                ],
-                children: [],
-              },
-            ],
-          },
-          {
-            type: "bulletListItem",
-            props: {
-              backgroundColor: "default",
-              textColor: "default",
-              textAlignment: "left",
+              ],
+              children: [],
             },
-            content: [
-              {
-                text: "Bullet List Item",
-                styles: [],
-              },
-            ],
-            children: [],
-          },
-        ],
-      },
-      {
-        type: "bulletListItem",
-        props: {
-          backgroundColor: "default",
-          textColor: "default",
-          textAlignment: "left",
+          ],
         },
-        content: [
-          {
-            text: "Bullet List Item",
-            styles: [],
-          },
-        ],
-        children: [],
-      },
-    ],
-  },
-  {
-    type: "bulletListItem",
-    props: {
-      backgroundColor: "default",
-      textColor: "default",
-      textAlignment: "left",
+      ],
     },
-    content: [
-      {
-        text: "Bullet List Item",
-        styles: [],
+    {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
       },
-    ],
-    children: [],
-  },
-];
+      content: [
+        {
+          text: "Paragraph",
+          styles: [
+            {
+              type: "textColor",
+              props: {
+                color: "purple",
+              },
+            },
+            {
+              type: "backgroundColor",
+              props: {
+                color: "green",
+              },
+            },
+          ],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "P",
+          styles: [],
+        },
+        {
+          text: "ara",
+          styles: [
+            {
+              type: "bold",
+              props: {},
+            },
+          ],
+        },
+        {
+          text: "grap",
+          styles: [
+            {
+              type: "italic",
+              props: {},
+            },
+          ],
+        },
+        {
+          text: "h",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "P",
+          styles: [],
+        },
+        {
+          text: "ara",
+          styles: [
+            {
+              type: "underline",
+              props: {},
+            },
+          ],
+        },
+        {
+          text: "grap",
+          styles: [
+            {
+              type: "strike",
+              props: {},
+            },
+          ],
+        },
+        {
+          text: "h",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "bulletListItem",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Bullet List Item",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "bulletListItem",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Bullet List Item",
+          styles: [],
+        },
+      ],
+      children: [
+        {
+          id: UniqueID.options.generateID(),
+          type: "bulletListItem",
+          props: {
+            backgroundColor: "default",
+            textColor: "default",
+            textAlignment: "left",
+          },
+          content: [
+            {
+              text: "Bullet List Item",
+              styles: [],
+            },
+          ],
+          children: [
+            {
+              id: UniqueID.options.generateID(),
+              type: "bulletListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Bullet List Item",
+                  styles: [],
+                },
+              ],
+              children: [],
+            },
+            {
+              id: UniqueID.options.generateID(),
+              type: "paragraph",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Paragraph",
+                  styles: [],
+                },
+              ],
+              children: [],
+            },
+            {
+              id: UniqueID.options.generateID(),
+              type: "numberedListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Numbered List Item",
+                  styles: [],
+                },
+              ],
+              children: [],
+            },
+            {
+              id: UniqueID.options.generateID(),
+              type: "numberedListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Numbered List Item",
+                  styles: [],
+                },
+              ],
+              children: [],
+            },
+            {
+              id: UniqueID.options.generateID(),
+              type: "numberedListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Numbered List Item",
+                  styles: [],
+                },
+              ],
+              children: [
+                {
+                  id: UniqueID.options.generateID(),
+                  type: "numberedListItem",
+                  props: {
+                    backgroundColor: "default",
+                    textColor: "default",
+                    textAlignment: "left",
+                  },
+                  content: [
+                    {
+                      text: "Numbered List Item",
+                      styles: [],
+                    },
+                  ],
+                  children: [],
+                },
+              ],
+            },
+            {
+              id: UniqueID.options.generateID(),
+              type: "bulletListItem",
+              props: {
+                backgroundColor: "default",
+                textColor: "default",
+                textAlignment: "left",
+              },
+              content: [
+                {
+                  text: "Bullet List Item",
+                  styles: [],
+                },
+              ],
+              children: [],
+            },
+          ],
+        },
+        {
+          id: UniqueID.options.generateID(),
+          type: "bulletListItem",
+          props: {
+            backgroundColor: "default",
+            textColor: "default",
+            textAlignment: "left",
+          },
+          content: [
+            {
+              text: "Bullet List Item",
+              styles: [],
+            },
+          ],
+          children: [],
+        },
+      ],
+    },
+    {
+      id: UniqueID.options.generateID(),
+      type: "bulletListItem",
+      props: {
+        backgroundColor: "default",
+        textColor: "default",
+        textAlignment: "left",
+      },
+      content: [
+        {
+          text: "Bullet List Item",
+          styles: [],
+        },
+      ],
+      children: [],
+    },
+  ];
 
-// const complexHTML: string = `<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p><span data-text-color="purple"><span data-background-color="green">Paragraph</span></span></p><p>P<strong>ara</strong><em>grap</em>h</p><p>P<u>ara</u><s>grap</s>h</p><ul><li><p>Bullet List Item</p></li><li><p>Bullet List Item</p><ul><li><p>Bullet List Item</p><ul><li><p>Bullet List Item</p></li></ul><p>Paragraph</p><ol><li><p>Numbered List Item</p></li><li><p>Numbered List Item</p></li><li><p>Numbered List Item</p><ol><li><p>Numbered List Item</p></li></ol></li></ol><ul><li><p>Bullet List Item</p></li></ul></li><li><p>Bullet List Item</p></li></ul></li><li><p>Bullet List Item</p></li></ul>`;
-//
-// const complexMarkdown: string = `# Heading 1
+// complexHTML = `<h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3><p><span data-text-color="purple"><span data-background-color="green">Paragraph</span></span></p><p>P<strong>ara</strong><em>grap</em>h</p><p>P<u>ara</u><s>grap</s>h</p><ul><li><p>Bullet List Item</p></li><li><p>Bullet List Item</p><ul><li><p>Bullet List Item</p><ul><li><p>Bullet List Item</p></li></ul><p>Paragraph</p><ol><li><p>Numbered List Item</p></li><li><p>Numbered List Item</p></li><li><p>Numbered List Item</p><ol><li><p>Numbered List Item</p></li></ol></li></ol><ul><li><p>Bullet List Item</p></li></ul></li><li><p>Bullet List Item</p></li></ul></li><li><p>Bullet List Item</p></li></ul>`;
+// complexMarkdown = `# Heading 1
 //
 // ## Heading 2
 //
@@ -700,28 +664,114 @@ const complexBlocks: PartialBlock[] = [
 //
 // *   Bullet List Item
 // `;
+});
+
+afterEach(() => {
+  editor._tiptapEditor.destroy()
+  editor = undefined;
+
+  delete (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS;
+});
+
+describe("Non-Nested Block/HTML/Markdown Conversions", () => {
+  it("Convert non-nested blocks to HTML", async () => {
+    const output = await editor.blocksToHTML(nonNestedBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert non-nested blocks to Markdown", async () => {
+    const output = await editor.blocksToMarkdown(nonNestedBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert non-nested HTML to blocks", async () => {
+    const output = await editor.HTMLToBlocks(nonNestedHTML);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert non-nested Markdown to blocks", async () => {
+    const output = await editor.markdownToBlocks(nonNestedMarkdown);
+
+    expect(output).toMatchSnapshot();
+  });
+});
+
+describe("Nested Block/HTML/Markdown Conversions", () => {
+  it("Convert nested blocks to HTML", async () => {
+    const output = await editor.blocksToHTML(nestedBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert nested blocks to Markdown", async () => {
+    const output = await editor.blocksToMarkdown(nestedBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+  // // Failing due to nested block parsing bug.
+  // it("Convert nested HTML to blocks", async () => {
+  //   const output = await editor.HTMLToBlocks(nestedHTML);
+  //
+  //   expect(output).toMatchSnapshot();
+  // });
+  // // Failing due to nested block parsing bug.
+  // it("Convert nested Markdown to blocks", async () => {
+  //   const output = await editor.markdownToBlocks(nestedMarkdown);
+  //
+  //   expect(output).toMatchSnapshot();
+  // });
+});
+
+describe("Styled Block/HTML/Markdown Conversions", () => {
+  it("Convert styled blocks to HTML", async () => {
+    const output = await editor.blocksToHTML(styledBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert styled blocks to Markdown", async () => {
+    const output = await editor.blocksToMarkdown(styledBlocks);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert styled HTML to blocks", async () => {
+    const output = await editor.HTMLToBlocks(styledHTML);
+
+    expect(output).toMatchSnapshot();
+  });
+
+  it("Convert styled Markdown to blocks", async () => {
+    const output = await editor.markdownToBlocks(styledMarkdown);
+
+    expect(output).toMatchSnapshot();
+  });
+});
 
 describe("Complex Block/HTML/Markdown Conversions", () => {
   it("Convert complex blocks to HTML", async () => {
-    const output = await editorAPI.blocksToHTML(complexBlocks);
+    const output = await editor.blocksToHTML(complexBlocks);
 
     expect(output).toMatchSnapshot();
   });
 
   it("Convert complex blocks to Markdown", async () => {
-    const output = await editorAPI.blocksToMarkdown(complexBlocks);
+    const output = await editor.blocksToMarkdown(complexBlocks);
 
     expect(output).toMatchSnapshot();
   });
   // // Failing due to nested block parsing bug.
   // it("Convert complex HTML to blocks", async () => {
-  //   const output = await editorAPI.HTMLToBlocks(complexHTML);
+  //   const output = await editor.HTMLToBlocks(complexHTML);
   //
   //   expect(output).toMatchSnapshot();
   // });
   // // Failing due to nested block parsing bug.
   // it("Convert complex Markdown to blocks", async () => {
-  //   const output = await editorAPI.markdownToBlocks(complexMarkdown);
+  //   const output = await editor.markdownToBlocks(complexMarkdown);
   //
   //   expect(output).toMatchSnapshot();
   // });

--- a/packages/core/test/nodeConversions.test.ts
+++ b/packages/core/test/nodeConversions.test.ts
@@ -1,34 +1,135 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { BlockNoteEditor, PartialBlock } from "../src";
 import {
   blockToNode,
   nodeToBlock,
 } from "../src/api/nodeConversions/nodeConversions";
+import UniqueID from "../src/extensions/UniqueID/UniqueID";
+import { Editor } from "@tiptap/core";
+import { Node } from "prosemirror-model";
 
-const editor = new BlockNoteEditor()._tiptapEditor;
+let editor: Editor;
 
-const simpleBlock: PartialBlock = {
-  type: "paragraph",
-};
-const simpleNode = editor.schema.nodes["blockContainer"].create(
-  {},
-  editor.schema.nodes["paragraph"].create()
-);
+let simpleBlock: PartialBlock;
+let simpleNode: Node;
+
+let complexBlock: PartialBlock;
+let complexNode: Node;
+
+beforeEach(() => {
+  (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS = {};
+
+  editor = new BlockNoteEditor()._tiptapEditor;
+
+  simpleBlock = {
+    type: "paragraph",
+  };
+  simpleNode = editor.schema.nodes["blockContainer"].create(
+    { id: UniqueID.options.generateID() },
+    editor.schema.nodes["paragraph"].create()
+  );
+
+  complexBlock = {
+    type: "heading",
+    props: {
+      backgroundColor: "blue",
+      textColor: "yellow",
+      textAlignment: "right",
+      level: "2",
+    },
+    content: [
+      {
+        text: "Heading ",
+        styles: [
+          {
+            type: "bold",
+            props: {},
+          },
+          {
+            type: "underline",
+            props: {},
+          },
+        ],
+      },
+      {
+        text: "2",
+        styles: [
+          {
+            type: "italic",
+            props: {},
+          },
+          {
+            type: "strike",
+            props: {},
+          },
+        ],
+      },
+    ],
+    children: [
+      {
+        type: "paragraph",
+        props: {
+          backgroundColor: "red",
+        },
+        content: "Paragraph",
+        children: [],
+      },
+      {
+        type: "bulletListItem",
+      },
+    ],
+  };
+  complexNode = editor.schema.nodes["blockContainer"].create(
+    {
+      id: UniqueID.options.generateID(),
+      backgroundColor: "blue",
+      textColor: "yellow",
+    },
+    [
+      editor.schema.nodes["heading"].create(
+        { textAlignment: "right", level: "2" },
+        [
+          editor.schema.text("Heading ", [
+            editor.schema.mark("bold"),
+            editor.schema.mark("underline"),
+          ]),
+          editor.schema.text("2", [
+            editor.schema.mark("italic"),
+            editor.schema.mark("strike"),
+          ]),
+        ]
+      ),
+      editor.schema.nodes["blockGroup"].create({}, [
+        editor.schema.nodes["blockContainer"].create(
+          { id: UniqueID.options.generateID(), backgroundColor: "red" },
+          [
+            editor.schema.nodes["paragraph"].create(
+              {},
+              editor.schema.text("Paragraph")
+            ),
+          ]
+        ),
+        editor.schema.nodes["blockContainer"].create(
+          { id: UniqueID.options.generateID() },
+          [editor.schema.nodes["bulletListItem"].create()]
+        ),
+      ]),
+    ]
+  );
+});
+
+afterEach(() => {
+  editor.destroy();
+  editor = undefined;
+
+  delete (window as Window & { __TEST_OPTIONS?: {} }).__TEST_OPTIONS;
+});
 
 describe("Simple ProseMirror Node Conversions", () => {
   it("Convert simple block to node", async () => {
     const firstNodeConversion = blockToNode(simpleBlock, editor.schema);
 
     expect(firstNodeConversion).toMatchSnapshot();
-
-    const firstBlockConversion = nodeToBlock(firstNodeConversion);
-
-    const secondNodeConversion = blockToNode(
-      firstBlockConversion,
-      editor.schema
-    );
-
-    expect(secondNodeConversion).toStrictEqual(simpleNode);
   });
 
   it("Convert simple node to block", async () => {
@@ -45,101 +146,11 @@ describe("Simple ProseMirror Node Conversions", () => {
   });
 });
 
-const complexBlock: PartialBlock = {
-  type: "heading",
-  props: {
-    backgroundColor: "blue",
-    textColor: "yellow",
-    textAlignment: "right",
-    level: "2",
-  },
-  content: [
-    {
-      text: "Heading ",
-      styles: [
-        {
-          type: "bold",
-          props: {},
-        },
-        {
-          type: "underline",
-          props: {},
-        },
-      ],
-    },
-    {
-      text: "2",
-      styles: [
-        {
-          type: "italic",
-          props: {},
-        },
-        {
-          type: "strike",
-          props: {},
-        },
-      ],
-    },
-  ],
-  children: [
-    {
-      type: "paragraph",
-      props: {
-        backgroundColor: "red",
-      },
-      content: "Paragraph",
-      children: [],
-    },
-    {
-      type: "bulletListItem",
-    },
-  ],
-};
-
-const complexNode = editor.schema.nodes["blockContainer"].create(
-  { backgroundColor: "blue", textColor: "yellow" },
-  [
-    editor.schema.nodes["heading"].create(
-      { textAlignment: "right", level: "2" },
-      [
-        editor.schema.text("Heading ", [
-          editor.schema.mark("bold"),
-          editor.schema.mark("underline"),
-        ]),
-        editor.schema.text("2", [
-          editor.schema.mark("italic"),
-          editor.schema.mark("strike"),
-        ]),
-      ]
-    ),
-    editor.schema.nodes["blockGroup"].create({}, [
-      editor.schema.nodes["blockContainer"].create({ backgroundColor: "red" }, [
-        editor.schema.nodes["paragraph"].create(
-          {},
-          editor.schema.text("Paragraph")
-        ),
-      ]),
-      editor.schema.nodes["blockContainer"].create({}, [
-        editor.schema.nodes["bulletListItem"].create(),
-      ]),
-    ]),
-  ]
-);
-
 describe("Complex ProseMirror Node Conversions", () => {
   it("Convert complex block to node", async () => {
     const firstNodeConversion = blockToNode(complexBlock, editor.schema);
 
     expect(firstNodeConversion).toMatchSnapshot();
-
-    const firstBlockConversion = nodeToBlock(firstNodeConversion);
-
-    const secondNodeConversion = blockToNode(
-      firstBlockConversion,
-      editor.schema
-    );
-
-    expect(secondNodeConversion).toStrictEqual(complexNode);
   });
 
   it("Convert complex node to block", async () => {

--- a/packages/core/test/nodeConversions.test.ts
+++ b/packages/core/test/nodeConversions.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { BlockNoteEditor, PartialBlock } from "../src";
 import {
-  PartialBlock,
-  BlockNoteEditor,
   blockToNode,
   nodeToBlock,
-} from "../src";
+} from "../src/api/nodeConversions/nodeConversions";
 
-const editor = new BlockNoteEditor().tiptapEditor;
+const editor = new BlockNoteEditor()._tiptapEditor;
 
 const simpleBlock: PartialBlock = {
   type: "paragraph",

--- a/packages/react/src/BlockNoteView.tsx
+++ b/packages/react/src/BlockNoteView.tsx
@@ -7,7 +7,7 @@ export function BlockNoteView(props: { editor: BlockNoteEditor | null }) {
   return (
     // TODO: Should we wrap editor in MantineProvider? Otherwise we have to duplicate color hex values.
     // <MantineProvider theme={BlockNoteTheme}>
-    <EditorContent editor={props.editor?.tiptapEditor || null} />
+    <EditorContent editor={props.editor?._tiptapEditor || null} />
     // </MantineProvider>
   );
 }

--- a/packages/react/src/hooks/useBlockNote.ts
+++ b/packages/react/src/hooks/useBlockNote.ts
@@ -1,9 +1,9 @@
 import { BlockNoteEditor, BlockNoteEditorOptions } from "@blocknote/core";
 import { DependencyList, useEffect, useState } from "react";
+import { ReactBlockSideMenuFactory } from "../BlockSideMenu/BlockSideMenuFactory";
 import { ReactFormattingToolbarFactory } from "../FormattingToolbar/FormattingToolbarFactory";
 import { ReactHyperlinkToolbarFactory } from "../HyperlinkToolbar/HyperlinkToolbarFactory";
 import { ReactSlashMenuFactory } from "../SlashMenu/SlashMenuFactory";
-import { ReactBlockSideMenuFactory } from "../BlockSideMenu/BlockSideMenuFactory";
 
 //based on https://github.com/ueberdosis/tiptap/blob/main/packages/react/src/useEditor.ts
 
@@ -42,7 +42,7 @@ export const useBlockNote = (
 
     setEditor(instance);
 
-    instance.tiptapEditor.on("transaction", () => {
+    instance._tiptapEditor.on("transaction", () => {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           if (isMounted) {
@@ -53,7 +53,7 @@ export const useBlockNote = (
     });
 
     return () => {
-      instance.tiptapEditor.destroy();
+      instance._tiptapEditor.destroy();
       isMounted = false;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This PR:

- removes the difference between BlockNoteEditor and EditorAPI. API methods are directly accessible on blocknoteeditor.
- renames tiptapEditor to _tiptapEditor to clarify it's only for internal use
- We only allow our own `BlockNoteEditorOptions` instead of having it extend from Tiptap's options. This way we can design + document our own API. (and if we want to at some point, we can remove TipTap later)