### PR TITLE
fix umd build for sandpack

### DIFF
--- a/examples/editor/package.json
+++ b/examples/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blocknote/example-editor",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@blocknote/core": "^0.4.2",
-    "@blocknote/react": "^0.4.2",
+    "@blocknote/react": "^0.4.3-alpha.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/editor/package.json
+++ b/examples/editor/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
-    "@vitejs/plugin-react": "^1.0.7",
+    "@vitejs/plugin-react": "^3.1.0",
     "eslint": "^8.10.0",
     "eslint-config-react-app": "^7.0.0",
     "typescript": "^4.5.4",

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "useWorkspaces": true,
-  "version": "0.4.2"
+  "version": "0.4.3-alpha.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       "devDependencies": {
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
-        "@vitejs/plugin-react": "^1.0.7",
+        "@vitejs/plugin-react": "^3.1.0",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "typescript": "^4.5.4",
@@ -5683,22 +5683,34 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
-      "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
+      "integrity": "sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.17.10",
-        "@babel/plugin-transform-react-jsx": "^7.17.3",
-        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
-        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
-        "@rollup/pluginutils": "^4.2.1",
-        "react-refresh": "^0.13.0",
-        "resolve": "^1.22.0"
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.27.0",
+        "react-refresh": "^0.14.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.1.0-beta.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -14833,9 +14845,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
-      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -17977,12 +17989,12 @@
       "devDependencies": {
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
-        "@vitejs/plugin-react": "^1.0.7",
+        "@vitejs/plugin-react": "^3.1.0",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "prettier": "^2.7.1",
         "typescript": "^4.5.4",
-        "vite": "^4.1.2",
+        "vite": "^4.1.4",
         "vite-plugin-eslint": "^1.8.1"
       },
       "peerDependencies": {
@@ -19618,7 +19630,7 @@
         "@blocknote/react": "^0.4.2",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
-        "@vitejs/plugin-react": "^1.0.7",
+        "@vitejs/plugin-react": "^3.1.0",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "react": "^18.2.0",
@@ -19650,13 +19662,13 @@
         "@tiptap/react": "2.0.0-beta.217",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
-        "@vitejs/plugin-react": "^1.0.7",
+        "@vitejs/plugin-react": "^3.1.0",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "prettier": "^2.7.1",
         "react-icons": "^4.3.1",
         "typescript": "^4.5.4",
-        "vite": "^4.1.2",
+        "vite": "^4.1.4",
         "vite-plugin-eslint": "^1.8.1"
       }
     },
@@ -22224,19 +22236,27 @@
       }
     },
     "@vitejs/plugin-react": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-1.3.2.tgz",
-      "integrity": "sha512-aurBNmMo0kz1O4qRoY+FM4epSA39y3ShWGuqfLRA/3z0oEJAdtoSfgA3aO98/PCCHAqMaduLxIxErWrVKIFzXA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-3.1.0.tgz",
+      "integrity": "sha512-AfgcRL8ZBhAlc3BFdigClmTUMISmmzHn7sB2h9U1odvc5U/MjWXsAaz18b/WoppUTDBzxOJwo2VdClfUcItu9g==",
       "dev": true,
       "requires": {
-        "@babel/core": "^7.17.10",
-        "@babel/plugin-transform-react-jsx": "^7.17.3",
-        "@babel/plugin-transform-react-jsx-development": "^7.16.7",
-        "@babel/plugin-transform-react-jsx-self": "^7.16.7",
-        "@babel/plugin-transform-react-jsx-source": "^7.16.7",
-        "@rollup/pluginutils": "^4.2.1",
-        "react-refresh": "^0.13.0",
-        "resolve": "^1.22.0"
+        "@babel/core": "^7.20.12",
+        "@babel/plugin-transform-react-jsx-self": "^7.18.6",
+        "@babel/plugin-transform-react-jsx-source": "^7.19.6",
+        "magic-string": "^0.27.0",
+        "react-refresh": "^0.14.0"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.27.0",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+          "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/sourcemap-codec": "^1.4.13"
+          }
+        }
       }
     },
     "@vitejs/plugin-vue": {
@@ -29059,9 +29079,9 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "react-refresh": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.13.0.tgz",
-      "integrity": "sha512-XP8A9BT0CpRBD+NYLLeIhld/RqG9+gktUjW1FkE+Vm7OCinbG1SshcK5tb9ls4kzvjZr9mOQc7HYgBngEyPAXg==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
+      "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
     },
     "react-textarea-autosize": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
     },
     "examples/editor": {
       "name": "@blocknote/example-editor",
-      "version": "0.4.2",
+      "version": "0.4.3-alpha.0",
       "dependencies": {
         "@blocknote/core": "^0.4.2",
-        "@blocknote/react": "^0.4.2",
+        "@blocknote/react": "^0.4.3-alpha.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -17975,7 +17975,7 @@
     },
     "packages/react": {
       "name": "@blocknote/react",
-      "version": "0.4.2",
+      "version": "0.4.3-alpha.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@blocknote/core": "^0.4.2",
@@ -18004,10 +18004,10 @@
     },
     "packages/website": {
       "name": "blocknote-website",
-      "version": "0.4.2",
+      "version": "0.4.3-alpha.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/react": "^0.4.2",
+        "@blocknote/react": "^0.4.3-alpha.0",
         "veaury": "^2.3.12",
         "vue-github-button": "^3.1.0"
       },
@@ -19627,7 +19627,7 @@
       "version": "file:examples/editor",
       "requires": {
         "@blocknote/core": "^0.4.2",
-        "@blocknote/react": "^0.4.2",
+        "@blocknote/react": "^0.4.3-alpha.0",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.1.0",
@@ -23042,7 +23042,7 @@
     "blocknote-website": {
       "version": "file:packages/website",
       "requires": {
-        "@blocknote/react": "^0.4.2",
+        "@blocknote/react": "^0.4.3-alpha.0",
         "@vue/tsconfig": "^0.1.3",
         "sass": "^1.58.0",
         "veaury": "^2.3.12",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/yousefed/blocknote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "files": [
     "dist",
     "types",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -57,12 +57,12 @@
   "devDependencies": {
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
-    "@vitejs/plugin-react": "^1.0.7",
+    "@vitejs/plugin-react": "^3.1.0",
     "eslint": "^8.10.0",
     "eslint-config-react-app": "^7.0.0",
     "prettier": "^2.7.1",
     "typescript": "^4.5.4",
-    "vite": "^4.1.2",
+    "vite": "^4.1.4",
     "vite-plugin-eslint": "^1.8.1"
   },
   "peerDependencies": {

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
           react: "React",
           "react-dom": "ReactDOM",
         },
+        interop: "compat", // https://rollupjs.org/migration/#changed-defaults
       },
     },
   },

--- a/packages/website/docs/.vitepress/theme/components/Sandbox/Sandbox.vue
+++ b/packages/website/docs/.vitepress/theme/components/Sandbox/Sandbox.vue
@@ -4,7 +4,7 @@
   <ClientOnly>
     <Sandbox
       :rtl="rtl"
-      :template="template"
+      :template="'react-ts'"
       :light-theme="lightTheme"
       :dark-theme="darkTheme"
       :options="{

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blocknote-website",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3-alpha.0",
   "description": "Website for BlockNote",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@blocknote/react": "^0.4.2",
+    "@blocknote/react": "^0.4.3-alpha.0",
     "veaury": "^2.3.12",
     "vue-github-button": "^3.1.0"
   },


### PR DESCRIPTION
The sandpack demos fail when Tippy components appear. The issue is that it doesn't correctly resolve the Tippy default import from `@tippyjs/react`


This is a regression from v0.3.0, which was built with an older version of Rollup. 

Old code shows `.default`, where new builds don't

<img width="396" alt="image" src="https://user-images.githubusercontent.com/368857/224487570-ac84d331-cea1-4b0b-89fa-e6f536ecd2ec.png">


