### PR TITLE
Fix node html parse

### DIFF
--- a/examples/editor/package.json
+++ b/examples/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blocknote/example-editor",
   "private": true,
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -9,8 +9,8 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.1",
-    "@blocknote/react": "^0.4.6-alpha.1",
+    "@blocknote/core": "^0.4.6-alpha.2",
+    "@blocknote/react": "^0.4.6-alpha.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/editor/package.json
+++ b/examples/editor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blocknote/example-editor",
   "private": true,
-  "version": "0.4.6-alpha.2",
+  "version": "0.4.6-alpha.3",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -9,8 +9,8 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.2",
-    "@blocknote/react": "^0.4.6-alpha.2",
+    "@blocknote/core": "^0.4.6-alpha.3",
+    "@blocknote/react": "^0.4.6-alpha.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blocknote/example-vanilla",
   "private": true,
-  "version": "0.4.6-alpha.2",
+  "version": "0.4.6-alpha.3",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -9,7 +9,7 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.2"
+    "@blocknote/core": "^0.4.6-alpha.3"
   },
   "devDependencies": {
     "eslint": "^8.10.0",

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@blocknote/example-vanilla",
   "private": true,
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -9,7 +9,7 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.1"
+    "@blocknote/core": "^0.4.6-alpha.2"
   },
   "devDependencies": {
     "eslint": "^8.10.0",

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "useWorkspaces": true,
-  "version": "0.4.6-alpha.2"
+  "version": "0.4.6-alpha.3"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": false,
   "useWorkspaces": true,
-  "version": "0.4.6-alpha.1"
+  "version": "0.4.6-alpha.2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
     },
     "examples/editor": {
       "name": "@blocknote/example-editor",
-      "version": "0.4.6-alpha.1",
+      "version": "0.4.6-alpha.2",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.1",
-        "@blocknote/react": "^0.4.6-alpha.1",
+        "@blocknote/core": "^0.4.6-alpha.2",
+        "@blocknote/react": "^0.4.6-alpha.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -38,9 +38,9 @@
     },
     "examples/vanilla": {
       "name": "@blocknote/example-vanilla",
-      "version": "0.4.6-alpha.1",
+      "version": "0.4.6-alpha.2",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.1"
+        "@blocknote/core": "^0.4.6-alpha.2"
       },
       "devDependencies": {
         "eslint": "^8.10.0",
@@ -17894,7 +17894,7 @@
     },
     "packages/core": {
       "name": "@blocknote/core",
-      "version": "0.4.6-alpha.1",
+      "version": "0.4.6-alpha.2",
       "license": "MPL-2.0",
       "dependencies": {
         "@emotion/cache": "^11.10.5",
@@ -17948,10 +17948,10 @@
     },
     "packages/react": {
       "name": "@blocknote/react",
-      "version": "0.4.6-alpha.1",
+      "version": "0.4.6-alpha.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.1",
+        "@blocknote/core": "^0.4.6-alpha.2",
         "@emotion/react": "^11.10.5",
         "@mantine/core": "^5.6.1",
         "@mantine/hooks": "^5.6.1",
@@ -17977,10 +17977,10 @@
     },
     "packages/website": {
       "name": "blocknote-website",
-      "version": "0.4.6-alpha.1",
+      "version": "0.4.6-alpha.2",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/react": "^0.4.6-alpha.1",
+        "@blocknote/react": "^0.4.6-alpha.2",
         "veaury": "^2.3.12",
         "vue-github-button": "^3.1.0"
       },
@@ -19602,8 +19602,8 @@
     "@blocknote/example-editor": {
       "version": "file:examples/editor",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.1",
-        "@blocknote/react": "^0.4.6-alpha.1",
+        "@blocknote/core": "^0.4.6-alpha.2",
+        "@blocknote/react": "^0.4.6-alpha.2",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.1.0",
@@ -19619,7 +19619,7 @@
     "@blocknote/example-vanilla": {
       "version": "file:examples/vanilla",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.1",
+        "@blocknote/core": "^0.4.6-alpha.2",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "typescript": "^4.5.4",
@@ -19630,7 +19630,7 @@
     "@blocknote/react": {
       "version": "file:packages/react",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.1",
+        "@blocknote/core": "^0.4.6-alpha.2",
         "@emotion/react": "^11.10.5",
         "@mantine/core": "^5.6.1",
         "@mantine/hooks": "^5.6.1",
@@ -23018,7 +23018,7 @@
     "blocknote-website": {
       "version": "file:packages/website",
       "requires": {
-        "@blocknote/react": "^0.4.6-alpha.1",
+        "@blocknote/react": "^0.4.6-alpha.2",
         "@vue/tsconfig": "^0.1.3",
         "sass": "^1.58.0",
         "veaury": "^2.3.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,10 @@
     },
     "examples/editor": {
       "name": "@blocknote/example-editor",
-      "version": "0.4.6-alpha.2",
+      "version": "0.4.6-alpha.3",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.2",
-        "@blocknote/react": "^0.4.6-alpha.2",
+        "@blocknote/core": "^0.4.6-alpha.3",
+        "@blocknote/react": "^0.4.6-alpha.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -38,9 +38,9 @@
     },
     "examples/vanilla": {
       "name": "@blocknote/example-vanilla",
-      "version": "0.4.6-alpha.2",
+      "version": "0.4.6-alpha.3",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.2"
+        "@blocknote/core": "^0.4.6-alpha.3"
       },
       "devDependencies": {
         "eslint": "^8.10.0",
@@ -17894,7 +17894,7 @@
     },
     "packages/core": {
       "name": "@blocknote/core",
-      "version": "0.4.6-alpha.2",
+      "version": "0.4.6-alpha.3",
       "license": "MPL-2.0",
       "dependencies": {
         "@emotion/cache": "^11.10.5",
@@ -17948,10 +17948,10 @@
     },
     "packages/react": {
       "name": "@blocknote/react",
-      "version": "0.4.6-alpha.2",
+      "version": "0.4.6-alpha.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "^0.4.6-alpha.2",
+        "@blocknote/core": "^0.4.6-alpha.3",
         "@emotion/react": "^11.10.5",
         "@mantine/core": "^5.6.1",
         "@mantine/hooks": "^5.6.1",
@@ -17977,10 +17977,10 @@
     },
     "packages/website": {
       "name": "blocknote-website",
-      "version": "0.4.6-alpha.2",
+      "version": "0.4.6-alpha.3",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/react": "^0.4.6-alpha.2",
+        "@blocknote/react": "^0.4.6-alpha.3",
         "veaury": "^2.3.12",
         "vue-github-button": "^3.1.0"
       },
@@ -19602,8 +19602,8 @@
     "@blocknote/example-editor": {
       "version": "file:examples/editor",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.2",
-        "@blocknote/react": "^0.4.6-alpha.2",
+        "@blocknote/core": "^0.4.6-alpha.3",
+        "@blocknote/react": "^0.4.6-alpha.3",
         "@types/react": "^18.0.25",
         "@types/react-dom": "^18.0.9",
         "@vitejs/plugin-react": "^3.1.0",
@@ -19619,7 +19619,7 @@
     "@blocknote/example-vanilla": {
       "version": "file:examples/vanilla",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.2",
+        "@blocknote/core": "^0.4.6-alpha.3",
         "eslint": "^8.10.0",
         "eslint-config-react-app": "^7.0.0",
         "typescript": "^4.5.4",
@@ -19630,7 +19630,7 @@
     "@blocknote/react": {
       "version": "file:packages/react",
       "requires": {
-        "@blocknote/core": "^0.4.6-alpha.2",
+        "@blocknote/core": "^0.4.6-alpha.3",
         "@emotion/react": "^11.10.5",
         "@mantine/core": "^5.6.1",
         "@mantine/hooks": "^5.6.1",
@@ -23018,7 +23018,7 @@
     "blocknote-website": {
       "version": "file:packages/website",
       "requires": {
-        "@blocknote/react": "^0.4.6-alpha.2",
+        "@blocknote/react": "^0.4.6-alpha.3",
         "@vue/tsconfig": "^0.1.3",
         "sass": "^1.58.0",
         "veaury": "^2.3.12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/yousefed/blocknote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.4.6-alpha.2",
+  "version": "0.4.6-alpha.3",
   "files": [
     "dist",
     "types",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/yousefed/blocknote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "files": [
     "dist",
     "types",

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
@@ -48,17 +48,17 @@ export const HeadingBlockContent = Node.create({
       {
         tag: "h1",
         attrs: { level: "1" },
-        node: "blockContainer",
+        node: "heading",
       },
       {
         tag: "h2",
         attrs: { level: "2" },
-        node: "blockContainer",
+        node: "heading",
       },
       {
         tag: "h3",
         attrs: { level: "3" },
-        node: "blockContainer",
+        node: "heading",
       },
     ];
   },

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -53,7 +53,7 @@ export const BulletListItemBlockContent = Node.create({
 
           return false;
         },
-        node: "blockContainer",
+        node: "bulletListItem",
       },
       // Case for BlockNote list structure.
       {
@@ -76,7 +76,7 @@ export const BulletListItemBlockContent = Node.create({
           return false;
         },
         priority: 300,
-        node: "blockContainer",
+        node: "bulletListItem",
       },
     ];
   },

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -73,7 +73,7 @@ export const NumberedListItemBlockContent = Node.create({
 
           return false;
         },
-        node: "blockContainer",
+        node: "numberedListItem",
       },
       // Case for BlockNote list structure.
       // (e.g.: when pasting from blocknote)
@@ -97,7 +97,7 @@ export const NumberedListItemBlockContent = Node.create({
           return false;
         },
         priority: 300,
-        node: "blockContainer",
+        node: "numberedListItem",
       },
     ];
   },

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
@@ -11,7 +11,7 @@ export const ParagraphBlockContent = Node.create({
       {
         tag: "p",
         priority: 200,
-        node: "blockContainer",
+        node: "paragraph",
       },
     ];
   },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/yousefed/blocknote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "files": [
     "dist",
     "types",
@@ -46,7 +46,7 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.1",
+    "@blocknote/core": "^0.4.6-alpha.2",
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.6.1",
     "@mantine/hooks": "^5.6.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -3,7 +3,7 @@
   "homepage": "https://github.com/yousefed/blocknote",
   "private": false,
   "license": "MPL-2.0",
-  "version": "0.4.6-alpha.2",
+  "version": "0.4.6-alpha.3",
   "files": [
     "dist",
     "types",
@@ -46,7 +46,7 @@
     "lint": "eslint src --max-warnings 0"
   },
   "dependencies": {
-    "@blocknote/core": "^0.4.6-alpha.2",
+    "@blocknote/core": "^0.4.6-alpha.3",
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.6.1",
     "@mantine/hooks": "^5.6.1",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blocknote-website",
   "private": true,
-  "version": "0.4.6-alpha.2",
+  "version": "0.4.6-alpha.3",
   "description": "Website for BlockNote",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@blocknote/react": "^0.4.6-alpha.2",
+    "@blocknote/react": "^0.4.6-alpha.3",
     "veaury": "^2.3.12",
     "vue-github-button": "^3.1.0"
   },

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blocknote-website",
   "private": true,
-  "version": "0.4.6-alpha.1",
+  "version": "0.4.6-alpha.2",
   "description": "Website for BlockNote",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "MPL-2.0",
   "dependencies": {
-    "@blocknote/react": "^0.4.6-alpha.1",
+    "@blocknote/react": "^0.4.6-alpha.2",
     "veaury": "^2.3.12",
     "vue-github-button": "^3.1.0"
   },


### PR DESCRIPTION
This seems to fix the HTML -> Node conversions. @matthewlipski Any reason why `node` was always set to `blockContainer`?

I'm not sure why this worked locally btw in the unit tests. But the published version now at least also works in codesandbox