### PR TITLE
`BNMergeBlocks` fix

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -277,10 +277,13 @@ export const BlockContainer = Node.create<IBlock>({
           }
 
           // Deletes next block and adds its text content to the nearest previous block.
-          // TODO: Use slices.
           if (dispatch) {
             state.tr.deleteRange(startPos, startPos + contentNode.nodeSize);
-            state.tr.insertText(contentNode.textContent, prevBlockEndPos - 1);
+            state.tr.replace(
+              prevBlockEndPos - 1,
+              undefined,
+              new Slice(Fragment.from(contentNode), depth - 1, depth - 1)
+            );
             state.tr.setSelection(
               new TextSelection(state.doc.resolve(prevBlockEndPos - 1))
             );


### PR DESCRIPTION
Previously, `BNMergeBlocks`, which is used to combine 2 blocks when pressing backspace at the start of one, only copied text from the latter block. This PR changes it to copy all content, meaning all `InlineContent` is preserved.